### PR TITLE
[IMP] Add type = normal while create asset

### DIFF
--- a/pabi_asset_management/models/asset_adjust.py
+++ b/pabi_asset_management/models/asset_adjust.py
@@ -397,12 +397,11 @@ class AccountAssetAdjust(models.Model):
         asset_dict = self._prepare_asset_dict(product, asset_name, analytic)
         asset_dict.update({'date_start': asset_date,
                            'purchase_value': amount,
+                           'type': 'normal',
                            })
         new_asset = Asset.create(asset_dict)
         new_asset.account_analytic_id = \
             Analytic.create_matched_analytic(new_asset)
-        # Set back to normal
-        new_asset.type = 'normal'
         return new_asset
 
     @api.multi


### PR DESCRIPTION
I don't sure for this because the sentence 'Set back to normal' cause to my confuse.

**Please check**
1. What is your objective set asset type back to normal after creating asset ?
2. If I change set asset type to normal while creating asset, Can I do ?

My issue >> https://mobileapp.nstda.or.th/redmine/issues/2330