### PR TITLE
[FIX] fix for issue 3036, use cancel reason for case cancel AV Clearing

### DIFF
--- a/hr_expense_advance_clearing/data/invoice_workflow.xml
+++ b/hr_expense_advance_clearing/data/invoice_workflow.xml
@@ -4,7 +4,7 @@
         <record id="t15_paid" model="workflow.transition">
             <field name="act_from" ref="account.act_paid"/>
             <field name="act_to" ref="account.act_cancel"/>
-            <field name="signal">inoice_cancel</field>
+            <field name="signal">invoice_cancel</field>
         </record>
     </data>
 </openerp>

--- a/pabi_account/models/account.py
+++ b/pabi_account/models/account.py
@@ -59,7 +59,11 @@ class AccountMove(models.Model):
                 continue
             # Normal case
             if rec.document_id and 'date_document' in rec.document_id:
-                rec.date_document = rec.document_id.date_document
+                # Cancel Case
+                if rec.document_id.cancel_date_document:
+                    rec.date_document = rec.document_id.cancel_date_document
+                else:
+                    rec.date_document = rec.document_id.date_document
             else:
                 if not self._context.get('direct_create'):
                     rec.date_document = fields.Date.context_today(self)

--- a/pabi_hr_expense/views/account_invoice_view.xml
+++ b/pabi_hr_expense/views/account_invoice_view.xml
@@ -15,13 +15,7 @@
                     	attrs="{'invisible': [('diff_expense_amount_flag', '!=', -1)]}"/>
                 </xpath>
 								<xpath expr="//button[@name='invoice_cancel']" position="before">
-										<!-- For case Advance Clearing Invoice + Cancel Reason -->
-										<!-- it should be either,
-										name="%(account_invoice_cancel_reason.action_account_invoice_cancel)d" type="action"
-										or
-										name="invoice_cancel" type="action"
-										but the workflow is not triggered by invoice_cancel, so, for now, I change to action_cancel -->
-										<button name="action_cancel" type="object"
+										<button name="%(account_invoice_cancel_reason.action_account_invoice_cancel)d" type="action"
 											attrs="{'invisible': ['|', ('supplier_invoice_type', '!=', 'advance_clearing_invoice'), ('state', '!=', 'paid')]}"
 											string="Cancel AV Clearing Invoice" groups="account.group_account_invoice"/>
 								</xpath>


### PR DESCRIPTION
Module require updates,

* hr_expense_advance_clearing -> fix cancel workflow
* pabi_hr_expense -> fix cancel button
* pabi_apps_config -> default update

:100755 100755 255b80ab 296ff404 M	hr_expense_advance_clearing/data/invoice_workflow.xml
:100755 100755 418caa6a 30b605ad M	pabi_account/models/account.py
:100755 100755 8603094e 07953185 M	pabi_hr_expense/views/account_invoice_view.xml