### PR TITLE
[ENH] add new column net_committed_amount in analytic_view

### DIFF
--- a/account_budget_activity/models/budget_commit.py
+++ b/account_budget_activity/models/budget_commit.py
@@ -39,6 +39,20 @@ class CommitCommon(object):
         track_visibility='onchange',
         help="If checked, all committed budget will be released",
     )
+    net_committed_amount = fields.Float(
+        string='Net Committed Amount',
+        compute='_compute_net_committed_amount',
+        store=True,
+        help="Committed Amount Remaining (Net)",
+    )
+
+    @api.multi
+    @api.depends('budget_commit_ids')
+    def _compute_net_committed_amount(self):
+        for rec in self:
+            rec.net_committed_amount = \
+                sum(rec.budget_commit_ids.mapped('amount'))
+        return True
 
     @api.multi
     def release_all_committed_budget(self):

--- a/pabi_budget_drilldown_report/views/analytic_view.xml
+++ b/pabi_budget_drilldown_report/views/analytic_view.xml
@@ -10,6 +10,7 @@
                     <field name="period_id"/>
                     <field name="charge_type"/>
                     <field name="document"/>
+                    <field name="net_committed_amount"/>
                     <field name="source_document"/>
                     <field name="docline_sequence"/>
                     <field name="date_document"/>


### PR DESCRIPTION
This commit require update of
1) account_budget_activity -> To create compute field net_committed_amount
2) pabi_budget_drilldown_report -> to add new column into analytic view

Note: since account_budget_activity is updated, please also update 
- pabi_budget_monitor
- pabi_budget_plan_monitor
- pabi_etl
and also, final with
- pabi_apps_config

Note2: Please deploy and test on test server first.

:100755 100755 c79a81eb 4b9ddd36 M	account_budget_activity/models/budget_commit.py
:100644 100644 b739daac 067c2444 M	pabi_budget_drilldown_report/models/analytic.py
:100644 100644 2039e056 9cd21d9b M	pabi_budget_drilldown_report/views/analytic_view.xml