### PR TITLE
fix recreate_all_budget_commitment call api error

### DIFF
--- a/account_budget_activity/models/budget_commit.py
+++ b/account_budget_activity/models/budget_commit.py
@@ -79,6 +79,7 @@ class CommitCommon(object):
             rec.budget_transition_ids.\
                 filtered('active').filtered('backward').\
                 regain_budget_commitment([line_field])
+        return True
 
     @api.multi
     def action_technical_closed(self):


### PR DESCRIPTION
FIX ERROR: 
cannot marshal None unless allow_none is enabled
TypeError: cannot marshal None unless allow_none is enabled