### PR TITLE
#3162_async_process

### DIFF
--- a/pabi_async_process/pabi_action_asset_compute/pabi_action_asset_compute.py
+++ b/pabi_async_process/pabi_action_asset_compute/pabi_action_asset_compute.py
@@ -239,7 +239,7 @@ class PabiActionAssetCompute(models.TransientModel):
         check_state_draft = self.env['pabi.asset.depre.batch'].search([('state', '=', 'draft')]) 
         if (check_state_draft):
             raise UserError(
-            _('มีการสร้าง Asset Depre. Batch อยู่แล้ว') )
+            _('Please delete the Draft state in the Asset Depre. Batch menu!!') )
 
         # Call the function
         res = super(PabiActionAssetCompute, self).\
@@ -266,7 +266,7 @@ class PabiActionAssetCompute(models.TransientModel):
         check_state_draft = self.env['pabi.asset.depre.batch'].search([('state', '=', 'draft')]) 
         if (check_state_draft):
             raise UserError(
-            _('มีการสร้าง Asset Depre. Batch อยู่แล้ว') )
+            _('Please delete the Draft state in the Asset Depre. Batch menu!!'))
  
         """ Based on matched assets, run through series of test """
         self.ensure_one()

--- a/pabi_async_process/pabi_action_asset_compute/pabi_depre_batch.py
+++ b/pabi_async_process/pabi_action_asset_compute/pabi_depre_batch.py
@@ -7,6 +7,7 @@ from openerp.exceptions import RedirectWarning
 from openerp.addons.connector.queue.job import job, related_action
 from openerp.addons.connector.session import ConnectorSession
 from openerp.addons.connector.exception import RetryableJobError
+from openerp.exceptions import Warning as UserError, ValidationError
 
 _logger = logging.getLogger(__name__)
 
@@ -131,6 +132,14 @@ class PabiAssetDepreBatch(models.Model):
 
     @api.multi
     def post_entries(self):
+        
+        #check state draft more than one
+        check_state_draft = self.env['pabi.asset.depre.batch'].search([('state', '=', 'draft')]) 
+        count_state_draft = len(check_state_draft.ids)
+        if(count_state_draft>=2):
+            raise UserError( 
+            _('Please check the Asset Depre. Batch menu, don\'t list the Draft state more than one!!'))
+        
         self.ensure_one()
         if self._context.get('job_uuid', False):  # Called from @job
             return self.action_post_entries()


### PR DESCRIPTION
1. เมนู Accounting -> Periodic Processing -> Recurring Entries -> Compute Assets

หลักการ

- เมื่อกดปุ่ม Execute ให้ตรวจสอบ model = pabi.asset.depre.batch ต้องไม่มี state = Draft อยู่เลย
  หากยังมี state = Draft ให้แสดง Error เป็นข้อความว่า "Please delete the Draft state in the Asset Depre. Batch menu!!"(แก้แสดง error เก่า)

2. เมนู Accounting -> Periodic Processing -> Asset Depre. Batch
   หลักการ

- เมื่อกดปุ่ม Post Entires กรณีมี state=Draft มากกว่า 1 อัน ให้แสดง Error ข้อความว่า "Please check the Asset Depre. Batch menu, don't list the Draft state more than one!!"