### PR TITLE
[FIX] #2939 asset use wrong value case tax included

### DIFF
--- a/pabi_purchase_invoice_plan/models/stock.py
+++ b/pabi_purchase_invoice_plan/models/stock.py
@@ -17,7 +17,7 @@ class StockPicking(models.Model):
                 wa = WA.browse(acceptance_id)
                 if wa.num_installment > 0:
                     asset_values = dict(
-                        [(x.product_id.id, x.price_unit)
+                        [(x.product_id.id, x.price_unit_untaxed)
                          for x in wa.acceptance_line_ids]
                     )
                     for picking in self:


### PR DESCRIPTION
To update -> pabi_purchase_work_acceptance

This should create new field **purchase_work_acceptance.price_unit_untaxed** and compute its values, please check.