### PR TITLE
[FIX] l10n_th_doctype_bank_recipt

### DIFF
--- a/l10n_th_doctype_bank_receipt/models/account_bank_receipt.py
+++ b/l10n_th_doctype_bank_receipt/models/account_bank_receipt.py
@@ -10,7 +10,11 @@ class AccountBankReceipt(models.Model):
         # Find doctype_id
         refer_type = 'bank_receipt'
         doctype = self.env['res.doctype'].get_doctype(refer_type)
-        fiscalyear_id = self.env['account.fiscalyear'].find()
+        # kittiu: use posting date
+        periods = self.env['account.period'].find(receipt.receipt_date)
+        period = periods and periods[0] or False
+        fiscalyear_id = period and period.fiscalyear_id.id or \
+            self.env['account.fiscalyear'].find()
         # --
         self = self.with_context(doctype_id=doctype.id,
                                  fiscalyear_id=fiscalyear_id)


### PR DESCRIPTION
Deployment:
- Restart only

Problem:
- ปัญหาที่มีคือ ตอนนี้ระบบใช้ Today ในการรันเลขที่เอกสาร

Solution:
- Use posting date for document sequence (instead of today)
