### PR TITLE
[FIX] 3878 - รายการผูกพัน PO ที่ยกยอดผูกพันพบว่าปี 2020 มียอดเบิ้ล

### DIFF
--- a/account_budget_activity/models/budget_commit.py
+++ b/account_budget_activity/models/budget_commit.py
@@ -66,7 +66,7 @@ class CommitCommon(object):
                     where active = true and id in %s
                 """, (tuple(trans_ids), ))
         return True
-        
+
     @api.multi
     def recreate_all_budget_commitment(self):
         """ This method is used for development only """
@@ -197,7 +197,8 @@ class CommitLineCommon(object):
                                     order='create_date desc', limit=1)
             rec.refresh()  # Clear cache
             if aline and rec.budget_commit_bal:
-                aline.copy({'amount': -rec.budget_commit_bal})
+                aline.copy({'date': fields.Date.context_today(self),
+                            'amount': -rec.budget_commit_bal})
 
     @api.model
     def _price_subtotal(self, line_qty):


### PR DESCRIPTION
คิดว่าปัญหาน่าจะเกิดจาก การ release_budget_commitment ครั้งแรกเท่านั้น จึงเป็นเหตุผลว่าการทำ recreate budget commitment แล้วถึงจะโอเค
เนื่องจากการ release_budget_commitment ครั้งแรกจะเป็นการ Copy() และกลับรายการจาก commitment ครั้งก่อนหน้าโดยการใช้วันที่เดียวกัน จากโค้ดส่วนนี้ budget_commit.py -> release_committed_budget()
จึงทำให้มันกลับไปใช้วันที่และปีเดิม 2019 แทนที่ปีใหม่ที่เราต้องการ 2020

**Solution:**
สำหรับการ release_committed_budget -> เปลี่ยนวันที่ date เป็นปัจจุบัน

