### PR TITLE
#3992 [ADD] pabi_mis_account_financial_report

### DIFF
--- a/pabi_mis_account_financial_report/__init__.py
+++ b/pabi_mis_account_financial_report/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2019 Ecosoft Co., Ltd. (https://ecosoft.co.th)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import models

--- a/pabi_mis_account_financial_report/__openerp__.py
+++ b/pabi_mis_account_financial_report/__openerp__.py
@@ -12,6 +12,7 @@
     'website': 'http://ecosoft.co.th',
     'depends': [
         'mis_builder',
+        'pabi_report_xlsx_helper',
     ],
     'data': [
         'data/mis_report_bs.xml',

--- a/pabi_mis_account_financial_report/__openerp__.py
+++ b/pabi_mis_account_financial_report/__openerp__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# © 2019 Ecosoft Co., Ltd. (https://ecosoft.co.th)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+{
+    'name': 'NSTDA :: MIS Accounting Financial Reports',
+    'version': '8.0.1.0.0',
+    'category': 'Reporting',
+    'description': """
+""",
+    'author': 'Saran Lim.',
+    'website': 'http://ecosoft.co.th',
+    'depends': [
+        'mis_builder',
+    ],
+    'data': [
+        'data/mis_report_bs.xml',
+        'data/mis.report.kpi.csv',
+    ],
+    'installable': True,
+    'auto_install': False,
+    'application': False,
+}

--- a/pabi_mis_account_financial_report/__openerp__.py
+++ b/pabi_mis_account_financial_report/__openerp__.py
@@ -17,6 +17,7 @@
     'data': [
         'data/mis_report_bs.xml',
         'data/mis.report.kpi.csv',
+        'views/mis_builder.xml',
     ],
     'installable': True,
     'auto_install': False,

--- a/pabi_mis_account_financial_report/data/mis.report.kpi.csv
+++ b/pabi_mis_account_financial_report/data/mis.report.kpi.csv
@@ -1,0 +1,1560 @@
+id,sequence,description,name,expression,default_css_style,dp,type,suffix,prefix,compare_method,report_id/id
+mis_report_bs_th1000000000,1,[1000000000]สินทรัพย์,1000000000,bale[1000000000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1100000000,2,[1100000000]สินทรัพย์หมุนเวียน,1100000000,bale[1100000000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101000000,3,[1101000000]เงินสดและรายการเทียบเท่าเงินสด,1101000000,bale[1101000000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101010000,4,[1101010000]เงินสด,1101010000,bale[1101010000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101010001,5,[1101010001]เงินสดย่อย,1101010001,bale[1101010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101010002,6,[1101010002]เงินสดในมือ,1101010002,bale[1101010002],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101010003,7,[1101010003]เช็ครับ,1101010003,bale[1101010003],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101019990,8,[1101019990]เงินสดในมือ Interface,1101019990,bale[1101019990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101020000,9,[1101020000]เงินฝากธนาคาร-ออมทรัพย์,1101020000,bale[1101020000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101020001,10,[1101020001]KTB CA 152-6-00424-0 สวทช.-เงินในงบประมาณ,1101020001,bale[1101020001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101020002,11,[1101020002]KTB CA 152-6-00426-7 สวทช.-เงินนอกงบประมาณ,1101020002,bale[1101020002],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101020003,12,[1101020003]KTB CA 152-6-00469-0 สวทช.-เงินเบิกแทนกัน,1101020003,bale[1101020003],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101020004,13,[1101020004]KTB SA 152-1-32668-1 CA 152-6-00244-2 สวทช.,1101020004,bale[1101020004],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101020005,14,[1101020005]KTB SA 013-1-51385-0 CA 013-6-08136-3 สถาบันวิทยาการ,1101020005,bale[1101020005],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101020006,15,[1101020006]KTB SA 152-1-32670-3 CA 152-6-00245-0 นักเรียนทุน,1101020006,bale[1101020006],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101020007,16,[1101020007]BBL SA 080-0-00001-0 CA 080-3-00001-7 สวทช.,1101020007,bale[1101020007],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101020008,17,[1101020008]BBL SA 080-0-01855-8 CA 080-3-00074-4 ศน.,1101020008,bale[1101020008],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101020009,18,[1101020009]BBL SA 080-0-00279-2 CA 080-3-00008-2 ศช.,1101020009,bale[1101020009],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101020010,19,[1101020010]BBL SA 080-0-00280-0 CA 080-3-00009-0 รายได้-ศช.,1101020010,bale[1101020010],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101020011,20,[1101020011]BBL SA 080-0-00084-6 CA 080-3-00003-3 ศว.,1101020011,bale[1101020011],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101020012,21,[1101020012]BBL SA 080-0-00178-6 รายได้-MTEC,1101020012,bale[1101020012],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101020013,22,[1101020013]BBL SA 080-0-04444-8 CA 080-3-00118-9 ศอ.,1101020013,bale[1101020013],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101020014,23,[1101020014]BBL SA 759-0-26380-7 ศช. ห้องปฏิบัติการสรีรวิทยาสัตว์,1101020014,bale[1101020014],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101020015,24,[1101020015]SCB SA 324-2-56262-0 CA 324-3-03140-2 ซอฟต์แวร์#2,1101020015,bale[1101020015],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101020016,25,[1101020016]SCB SA 667-2-15866-7 CA 667-3-00344-1 สวทช. ภาคเหนือ,1101020016,bale[1101020016],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101020017,26,[1101020017]SCB SA 541-2-30920-2 CA 541-3-00951-2 ศวพก.,1101020017,bale[1101020017],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101020018,27,[1101020018]TMB SA 069-2-19922-7 หน่วยฯ แป้ง (รายได้),1101020018,bale[1101020018],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101020019,28,[1101020019]BAY SA 329-1-34850-3 CA 329-0-01347-6 ซอฟต์แวร์#2,1101020019,bale[1101020019],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101020020,29,[1101020020]BBL SA 080-0-07531-9 CA 080-3-00162-7 กฟผ.-สวทช.,1101020020,bale[1101020020],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101020021,30,[1101020021]BBL CA101-3-15558-3สนง.คณะกรรมการพัฒนาวิทยาศาสตร์ฯ,1101020021,bale[1101020021],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101020022,31,[1101020022]KTB CA 475-6-00353-2 โครงการเงินกู้เพื่อพัฒนาระบบ,1101020022,bale[1101020022],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101020023,32,[1101020023]BBL SA 080-0-12726-8 CA 080-3-00274-0  CTEC,1101020023,bale[1101020023],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101020024,33,[1101020024]BBL SA 080-0-04983-5 CA 080-3-00121-3  DECC,1101020024,bale[1101020024],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101020025,34,[1101020025]BBL SA 080-0-13324-1 เงินบริจาคกองทุนพัฒนาวิทยาศาสตร์,1101020025,bale[1101020025],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101029990,35,[1101029990]เงินฝากธนาคาร-ออมทรัพย์ Interface,1101029990,bale[1101029990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101030000,36,[1101030000]เงินฝากธนาคาร-ประจำ 3 เดือน,1101030000,bale[1101030000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101030001,37,[1101030001]GSB SA 3-001798250-9 [3 เดือน] สวทช.,1101030001,bale[1101030001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101030002,38,[1101030002]BBL FA 080-2-01168-4 [14 วัน] สวทช.,1101030002,bale[1101030002],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101030003,39,[1101030003]TNC FA 482-1-10953-6 [1 เดือน] สวทช.,1101030003,bale[1101030003],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101030004,40,[1101030004]BAY FA 669-2-01017-8 [2 เดือน] สวทช.,1101030004,bale[1101030004],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101030005,41,[1101030005]SCB FA 464-018272-9 สวทช.,1101030005,bale[1101030005],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101039990,42,[1101039990]เงินฝากธนาคาร-ประจำ Interface,1101039990,bale[1101039990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101040000,43,[1101040000]เงินฝากธนาคารที่มีวัตถุประสงค์เฉพาะ,1101040000,bale[1101040000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050000,44,[1101050000]เงินฝากธนาคารที่มีวัตถุประสงค์เฉพาะ-สกสว.,1101050000,bale[1101050000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050001,45,[1101050001]BBL SA 080-0-10037-2 CA 080-3-00215-3 ทุนวิจัย สกว.-สวทช.,1101050001,bale[1101050001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050002,46,[1101050002]BBL SA 080-0-11452-2 CA 080-3-00251-8 TRG58-กรกช,1101050002,bale[1101050002],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050003,47,[1101050003]BBL SA 080-0-11551-1 CA 080-3-00257-5 RSA58-ชัยรัตน์,1101050003,bale[1101050003],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050004,48,[1101050004]BBL SA 080-0-11555-2 CA 080-3-00259-1 BRG58-ปิติ,1101050004,bale[1101050004],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050005,49,[1101050005]BBL SA 080-0-11556-0 CA 080-3-00260-9 RSA58-ศิษเฎศ,1101050005,bale[1101050005],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050006,50,[1101050006]BBL SA 080-0-11576-8 CA 080-3-00262-5 RSA58-เปรมฤทัย,1101050006,bale[1101050006],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050007,51,[1101050007]BBL SA 080-0-11755-8 CA 080-3-00272-4 TN-มาซาฮิโกะ,1101050007,bale[1101050007],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050008,52,[1101050008]BBL SA 080-0-11894-5 CA 080-3-00276-5 RDG5850103-พิมพา,1101050008,bale[1101050008],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050009,53,[1101050009]KTB SA 475-3-20610-6 CA 475-6-00500-4 ทุนวิจัย สกว,1101050009,bale[1101050009],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050010,54,[1101050010]BBL SA 080-0-13037-9 CA 080-3-00336-7 เศรษฐลัทธ์,1101050010,bale[1101050010],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050011,55,[1101050011]BBL SA 080-0-12002-4 CA 080-3-00286-4 TN-คทาวุธ,1101050011,bale[1101050011],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050012,56,[1101050012]BBL SA 080-0-12003-2 CA 080-3-00287-2 TN-สินีนาฏ,1101050012,bale[1101050012],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050013,57,[1101050013]BBL SA 080-0-12004-0 CA 080-3-00288-0 TN-นพดล,1101050013,bale[1101050013],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050014,58,[1101050014]BBL SA 080-0-12365-5 CA 080-3-00297-1 TN-วัชริน ม.,1101050014,bale[1101050014],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050015,59,[1101050015]BBL SA 080-0-12377-0 CA 080-3-00301-1 TN-อัยดา อ.,1101050015,bale[1101050015],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050016,60,[1101050016]BBL SA 080-0-12374-7 CA 080-3-00298-9 TN-จีราพร ล.,1101050016,bale[1101050016],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050017,61,[1101050017]BBL SA 080-0-12375-4 CA 080-3-00299-7 TN-สัญชัย ค.,1101050017,bale[1101050017],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050018,62,[1101050018]BBL SA 080-0-12376-2 CA 080-3-00300-3 TN-สุวัสสา บ,1101050018,bale[1101050018],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050019,63,[1101050019]BBL SA 080-0-12402-6 CA 080-3-00306-0 TN-ธริดาพร บ,1101050019,bale[1101050019],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050020,64,[1101050020]BBL SA 080-0-12405-9 CA 080-3-00309-4 TN-สุธา ส.,1101050020,bale[1101050020],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050021,65,[1101050021]BBL SA 080-0-12403-4 CA 080-3-00307-8 TN-ชลรัชต์ บ,1101050021,bale[1101050021],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050022,66,[1101050022]BBL SA 080-0-12404-2 CA 080-3-00308-6 TN-ศันสนีย น,1101050022,bale[1101050022],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050023,67,[1101050023]BBL SA 080-0-12388-7 CA 080-3-003037 TN-ขจรศักดิ์,1101050023,bale[1101050023],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050024,68,[1101050024]BBL SA 080-0-12428-1 CA 080-3-00311-0 TN-กัลยาณ์ ศ.,1101050024,bale[1101050024],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050025,69,[1101050025]BBL SA 080-0-12508-0 CA 080-3-00312-8 TN-ณัฐกา ส.,1101050025,bale[1101050025],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050026,70,[1101050026]BBL SA 080-0-12509-8 CA 080-3-00313-6 TN-ชญาภา น.,1101050026,bale[1101050026],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050027,71,[1101050027]BBL SA 080-0-12511-4 CA 080-3-00315-1 TN-อนุชา ว.,1101050027,bale[1101050027],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050028,72,[1101050028]BBL SA 080-0-12642-7 CA 080-3-00319-3 TN-วีระวัฒน์,1101050028,bale[1101050028],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050029,73,[1101050029]BBL SA 080-0-12643-5 CA 080-3-00320-1 TN-จักรพล,1101050029,bale[1101050029],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050030,74,[1101050030]BBL SA 080-0-12677-3 CA 080-3-00321-9 TN-ชัยยันต์,1101050030,bale[1101050030],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050031,75,[1101050031]BBL SA 080-0-12683-1 CA 080-3-00322-7 TN-พรพรรณ,1101050031,bale[1101050031],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050032,76,[1101050032]BBL SA 080-0-12693-0 CA 080-3-00324-3 TN-ไพศาล,1101050032,bale[1101050032],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050033,77,[1101050033]BBL SA 080-0-12695-5 CA 080-3-00325-0 TN- ยศวัต,1101050033,bale[1101050033],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050034,78,[1101050034]BBL SA 080-0-11959-6 CA 080-3-00282-3 TN-สิรินาถ,1101050034,bale[1101050034],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050035,79,[1101050035]KTB SA 475-3-09516-9 CA 475-6-00419-9 TN-อุรชา ร.,1101050035,bale[1101050035],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050036,80,[1101050036]KTB SA 475-3-14302-3 CA 475-6-00462-8 TN-เทพชัย,1101050036,bale[1101050036],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050037,81,[1101050037]KTB SA 475-3-19784-0 CA 475-6-00485-7 TN-ธงชัย ก.,1101050037,bale[1101050037],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050038,82,[1101050038]BBL SA 080-0-11961-2 CA 080-3-00284-9 TN-ปัทมา,1101050038,bale[1101050038],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050039,83,[1101050039]BBL SA 080-0-13120-3 CA 080-3-00341-7 TN-กิตติพงษ์,1101050039,bale[1101050039],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050040,84,[1101050040]BBL SA 080-0-13122-9 CA 080-3-00343-3 TN-ธิติกร,1101050040,bale[1101050040],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050041,85,[1101050041]BBL SA 080-0-13149-2 CA 080-3-00346-6 TN-อัญชลี,1101050041,bale[1101050041],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050042,86,[1101050042]BBL SA 080-0-12692-2 CA 080-3-00323-5 TN-นิทัศน์ (DECC),1101050042,bale[1101050042],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050043,87,[1101050043]BBL SA 080-0-13258-1 CA 080-3-00347-4 PT-ปัทมา,1101050043,bale[1101050043],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050053,88,[1101050053]BBL SA 080-0-13413-2 CA 080-3-00359-9 TN-ณรงค์ พ.50026,1101050053,bale[1101050053],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050054,89,[1101050054]BBL SA 080-0-13426-4 CA 080-3-00360-7 TN-ศราวุธ ล.50032,1101050054,bale[1101050054],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050055,90,[1101050055]BBL SA 080-0-13455-3 CA 080-3-00361-5 TN-ปัทมา พ.20019,1101050055,bale[1101050055],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050056,91,[1101050056]BBL SA 080-0-13482-7 CA 080-3-00362-3 TN-ศราวุธ ล.50039,1101050056,bale[1101050056],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050057,92,[1101050057]BBL SA 080-013541-0 CA 080-3-00363-1 โรคติดเชื้อในสัตว์,1101050057,bale[1101050057],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050044,93,[1101050044]BBL SA 080-0-13301-9 CA 080-3-00350-8 TN-วรรณพ.ว.50009,1101050044,bale[1101050044],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050045,94,[1101050045]BBL SA 080-0-13298-7 CA 080-3-00348-2 TN-วรรณพ.ว.50006,1101050045,bale[1101050045],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050046,95,[1101050046]BBL SA 080-0-13299-5 CA 080-3-00349-0 TN-วรรณพ.ว.50008,1101050046,bale[1101050046],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050047,96,[1101050047]BBL SA 080-0-13302-7 CA 080-3-00351-6 TN-เกื้อกูล.ป.50002,1101050047,bale[1101050047],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050048,97,[1101050048]BBL SA 080-0-13311-8 CA 080-3-00355-7 TN-วรรณพ.ว.50003,1101050048,bale[1101050048],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050049,98,[1101050049]BBL SA 080-0-13308-4 CA 080-3-00352-4 TN-วรรณพ.ว.50004,1101050049,bale[1101050049],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050050,99,[1101050050]BBL SA 080-0-13309-2 CA 080-3-00353-2 TN-วรรณพ.ว.50005,1101050050,bale[1101050050],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050051,100,[1101050051]BBL SA 080-0-13310-0 CA 080-3-00354-0 'TN-วรรณพ.ว.50007,1101050051,bale[1101050051],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101050052,101,[1101050052]BBL SA 080-0-13326-6 CA 080-3-00357-3 TN-วรรณพ.ว.50010,1101050052,bale[1101050052],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101060000,102,[1101060000]เงินฝากธนาคารที่มีวัตถุประสงค์เฉพาะ-สวก.,1101060000,bale[1101060000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101060001,103,[1101060001]KTB SA 475-0-88623-8 CA 475-6-00303-6 ผลิตเม็ดพันธุ์,1101060001,bale[1101060001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101060003,104,[1101060003]BBL SA 080-0-12390-3 CA 080-3-00305-2 อาหารกุ้ง,1101060003,bale[1101060003],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101060004,105,[1101060004]BBL SA 080-0-12389-5 CA 080-3-00304-5ต้านการอักเสบ,1101060004,bale[1101060004],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101060005,106,[1101060005]BBL SA 080-0-12406-7 CA 080-3-00310-2 ข้าวทนหนาว,1101060005,bale[1101060005],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101060006,107,[1101060006]BBL SA 080-0-12512-2 CA 080-3-00316-9 สิ่งทอไล่ยุง,1101060006,bale[1101060006],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101060007,108,[1101060007]BBL SA 080-0-12510-6 CA 080-3-00314-4 จำแนกสปีชีส์,1101060007,bale[1101060007],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101060008,109,[1101060008]KTB SA 475-3-08198-2 CA 475-6-00414-8 สีผิวผลปาล์ม,1101060008,bale[1101060008],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101060009,110,[1101060009]KTB SA 475-3-10171-1 CA 475-6-00432-6 เมทาโบไลท์,1101060009,bale[1101060009],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101060010,111,[1101060010]KTB SA 475-3-10170-3 CA 475-6-00431-8 โปรตีโอมิกส์,1101060010,bale[1101060010],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101060011,112,[1101060011]KTB SA 475-3-10410-9 CA 475-6-00437-7 ตรวจมะละกอ,1101060011,bale[1101060011],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101060014,113,[1101060014]KTB SA 475-3-10748-5 CA 475-6-00450-4 เนื้อเยื่อ,1101060014,bale[1101060014],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101060015,114,[1101060015]KTB SA 475-3-19732-8 CA 475-6-00483-0 ข้าวลูกผสม#3,1101060015,bale[1101060015],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101060016,115,[1101060016]KTB SA 475-3-19733-6 CA 475-6-00484-9 พิมพ์ DNA#3,1101060016,bale[1101060016],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101060017,116,[1101060017]KTB SA 475-3-20777-3 CA 475-6-00502-0 การประยุกต์,1101060017,bale[1101060017],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101060018,117,[1101060018]KTB SA 475-3-21238-6 CA 475-6-00519-5 การประเมิน,1101060018,bale[1101060018],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101060019,118,[1101060019]KTB SA 475-3-21824-4 CA 475-6-00549-7 มะพร้าวไทย,1101060019,bale[1101060019],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101060020,119,[1101060020]KTB SA 475-3-21840-6 CA 475-6-00550-0 พันธุกรรมข้าว,1101060020,bale[1101060020],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101060021,120,[1101060021]KTB SA 475-3-21839-2 CA 475-6-00551-9 ข้าวเรณู,1101060021,bale[1101060021],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101060022,121,[1101060022]KTB SA 475-3-21867-8 CA 475-6-00552-7 แม่เป็นหมัน,1101060022,bale[1101060022],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101060023,122,[1101060023]KTB SA 475-3-21894-5 CA 475-6-00553-5 การปลูกอ้อย,1101060023,bale[1101060023],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101060024,123,[1101060024]KTB SA 475-3-30630-5 CA 475-6-00561-6  นิวคลีโอไทด์,1101060024,bale[1101060024],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101060025,124,[1101060025]KTB SA 475-3-31608-4 CA 475-6-00572-1  ปลากัดไทย,1101060025,bale[1101060025],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101060026,125,[1101060026]KTB SA 475-3-31624-6 CA 475-6-00574-8  โรคในปลานิล,1101060026,bale[1101060026],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101060027,126,[1101060027]KTB SA 475-3-31625-4 CA 475-6-00575-6  เมล็ดพริก,1101060027,bale[1101060027],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101060028,127,[1101060028]BBL SA 080-0-11748-3 CA 080-3-00271-6 โรงเรือนกล้วยไม้ (DECC),1101060028,bale[1101060028],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101060029,128,[1101060029]KTB SA 475-3-31713-7 CA 475-6-00578-0 ผลิตภัณฑ์สุกร,1101060029,bale[1101060029],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101060030,129,[1101060030]KTB SA 475-3-31956-3 CA 475-6-00580-2 โรคใบขาวของอ้อย,1101060030,bale[1101060030],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101060031,130,[1101060031]KTB SA 475-3-32011-1 CA 475-6-00583-7 กุ้งขาวแวนนาไม,1101060031,bale[1101060031],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101060032,131,[1101060032]KTB SA 475-3-32032-4 CA 475-6-00584-5 สไปรูลินา,1101060032,bale[1101060032],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101060033,132,[1101060033]KTB SA 475-3-32078-2 CA 475-6-00585-3 อาหารกุ้ง (ปีที่ ๒),1101060033,bale[1101060033],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101060034,133,[1101060034]KTB SA 475-3-32218-1 CA 475-6-00595-0 เชื้อ EHP ในกุ้งขาว,1101060034,bale[1101060034],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101060035,134,[1101060035]KTB SA 475-3-32271-8 CA 475-6-00596-9 เรณูเป็นหมัน,1101060035,bale[1101060035],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101060036,135,[1101060036]KTB SA 475-3-32603-9 CA 475-6-00608-6 ขยายพันธุ์ปาล์ม (ปีที่ 3),1101060036,bale[1101060036],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101060037,136,[1101060037]KTB SA 475-3-39835-8 CA 475-6-00612-4 ความสุกของปาล์ม (ปีที่ 2),1101060037,bale[1101060037],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101060038,137,[1101060038]KTB SA 475-3-41696-8 CA 475-6-00622-1 พัฒนาฐานข้อมูล,1101060038,bale[1101060038],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101070000,138,[1101070000]เงินฝากธนาคารที่มีวัตถุประสงค์เฉพาะ-สสส.,1101070000,bale[1101070000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101070001,139,[1101070001]BBL SA 080-0-12334-1 CA 080-3-00294-8 ผู้สูงอายุ,1101070001,bale[1101070001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101080000,140,[1101080000]เงินฝากธนาคารที่มีวัตถุประสงค์เฉพาะ-วช.,1101080000,bale[1101080000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101080002,141,[1101080002]KTB SA 475-0-64783-7 CA 475-6-00181-5 ศช. (การพัฒนาคุณภาพของผลมะละกอฯ),1101080002,bale[1101080002],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101080003,142,[1101080003]KTB SA 475-0-76367-5 CA 475-6-00215-3 สำปะหลัง วช.56,1101080003,bale[1101080003],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101080004,143,[1101080004]KTB SA 475-0-76369-1 CA 475-6-00216-1 ระบบราง วช.56,1101080004,bale[1101080004],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101080005,144,[1101080005]KTB SA 475-0-78591-1 CA 475-6-00253-6 สำปะหลัง วช.57,1101080005,bale[1101080005],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101080006,145,[1101080006]KTB SA 475-0-79325-6 CA 475-6-00258-7 ระบบราง วช.57,1101080006,bale[1101080006],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101080007,146,[1101080007]KTB SA 475-0-88852-4 CA 475-6-00317-6 ลดมลพิษ,1101080007,bale[1101080007],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101080008,147,[1101080008]KTB SA 475-0-88875-3 CA 475-6-00318-4 สำปะหลัง วช.58,1101080008,bale[1101080008],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101080009,148,[1101080009]KTB SA 475-0-88878-8 CA 475-6-00319-2 ระบบราง วช.58,1101080009,bale[1101080009],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101080010,149,[1101080010]KTB SA 475-0-89246-7 CA 475-6-00327-3 ชนิดดูดซึม,1101080010,bale[1101080010],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101080011,150,[1101080011]KTB SA 475-0-89362-5 CA 475-6-00333-8 กุ้งตายด่วน,1101080011,bale[1101080011],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101080012,151,[1101080012]KTB SA 475-0-89395-1 CA 475-6-00336-2 ตั๊กแตน,1101080012,bale[1101080012],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101080013,152,[1101080013]KTB SA 475-0-97573-7 CA 475-6-00349-4 วัสดุนาโน,1101080013,bale[1101080013],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101080014,153,[1101080014]KTB SA 475-0-99621-1 CA 475-6-00378-8 ระบบราง วช.59,1101080014,bale[1101080014],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101080015,154,[1101080015]KTB SA 475-0-99620-3 CA 475-6-00376-1 สำปะหลัง วช.59,1101080015,bale[1101080015],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101080016,155,[1101080016]KTB SA 475-3-00316-7 CA475-6-00402-4เคมีไฟฟ้าพกพา2,1101080016,bale[1101080016],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101080017,156,[1101080017]KTB SA 475-3-00474-0 CA 475-6-00405-9 ประยุกต์ใช้,1101080017,bale[1101080017],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101080018,157,[1101080018]BBL SA 080-0-09735-4 CA 080-3-00205-4 สวทช.-แผ่นกรองอากาศนาโน,1101080018,bale[1101080018],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101080019,158,[1101080019]KTB SA 475-3-09637-8 CA 475-6-00420-2 จมูกอัจฉริยะ,1101080019,bale[1101080019],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101080020,159,[1101080020]KTB SA 475-3-09671-8 CA 475-6-00422-9 เดนตีสแกน,1101080020,bale[1101080020],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101080021,160,[1101080021]KTB SA 475-3-10409-5 CA 475-6-00436-9 พิพิธภัณฑ์,1101080021,bale[1101080021],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101080022,161,[1101080022]KTB SA 475-3-10572-5 CA 475-6-00448-2สำปะหลัง วช60,1101080022,bale[1101080022],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101080023,162,[1101080023]KTB SA 475-3-10571-7 CA 475-6-00447-4 ระบบราง วช60,1101080023,bale[1101080023],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101080024,163,[1101080024]KTB SA 475-3-14306-6 CA 475-6-00464-4 ขนส่ง วช.59,1101080024,bale[1101080024],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101080026,164,[1101080026]KTB SA 475-3-19382-9 CA 475-6-00481-4 ผลิตอนุภาคนา,1101080026,bale[1101080026],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101080027,165,[1101080027]KTB SA 475-3-21562-8 CA 475-6-00537-3 การพัฒนา,1101080027,bale[1101080027],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101090000,166,[1101090000]เงินฝากธนาคารที่มีวัตถุประสงค์เฉพาะ-แหล่งอื่น ๆ,1101090000,bale[1101090000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101090001,167,[1101090001]BBL SA 080-0-07530-1 CA 080-3-00163-5 Tokyo tech,1101090001,bale[1101090001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101090002,168,[1101090002]BBL SA 080-0-09540-8 CA 080-3-00198-1 มอเตอร์และระบบขับเคลื่อน,1101090002,bale[1101090002],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101090003,169,[1101090003]BBL SA 080-0-12356-4 CA 080-3-00296-3 DAM SAFETY,1101090003,bale[1101090003],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101090004,170,[1101090004]BBL SA 080-0-12383-8 CA 080-3-00302-9 NETPIE IOT,1101090004,bale[1101090004],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101090005,171,[1101090005]BBL SA 080-0-12513-0 CA 080-3-00317-7 แบบจำลอง,1101090005,bale[1101090005],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101090006,172,[1101090006]BBL SA 080-0-12839-9 CA 080-3-00327-6 เงินนอก ศอ.,1101090006,bale[1101090006],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101090008,173,[1101090008]BBL SA 080-0-12908-2 CA 080-3-00329-2 สหสถาบัน,1101090008,bale[1101090008],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101090009,174,[1101090009]BBL SA 080-0-12989-2 CA 080-3-00330-0 ค้นหายา,1101090009,bale[1101090009],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101090010,175,[1101090010]BBL SA 080-0-12994-2 CA 080-3-00331-8 เก็บพลังงาน,1101090010,bale[1101090010],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101090011,176,[1101090011]BBL SA 080-0-12999-1 CA 080-3-00332-6 SolarMove,1101090011,bale[1101090011],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101090012,177,[1101090012]BBL SA 080-0-13000-7 CA 080-3-00333-4 Health,1101090012,bale[1101090012],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101090013,178,[1101090013]BBL SA 080-0-13019-7 CA 080-3-00334-2 ผู้ประกอบการ,1101090013,bale[1101090013],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101090015,179,[1101090015]BBL SA 080-0-13050-2 CA 080-3-00337-5 เพอรอฟสไกต์,1101090015,bale[1101090015],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101090016,180,[1101090016]KTB SA 475-3-08320-9 CA 475-6-00417-2Energy-บริหาร,1101090016,bale[1101090016],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101090017,181,[1101090017]KTB SA 475-3-08322-5 CA 475-6-00418-0Energyอุดหนุน,1101090017,bale[1101090017],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101090018,182,[1101090018]KTB SA 475-3-09923-7 CA 475-6-00423-7 ไบโอดีเซล,1101090018,bale[1101090018],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101090019,183,[1101090019]KTB SA 475-3-14305-8 CA 475-6-00463-6 กองทุนฯ,1101090019,bale[1101090019],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101090020,184,[1101090020]KTB SA 475-3-20534-7 CA 475-6-00495-4 พัฒนาผงสี,1101090020,bale[1101090020],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101090021,185,[1101090021]KTB SA 475-3-20533-9 CA 475-6-00494-6การใช้พลังงาน,1101090021,bale[1101090021],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101090022,186,[1101090022]KTB SA 475-3-20876-1 CA 475-6-00509-8 เยื่อเลือก,1101090022,bale[1101090022],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101090023,187,[1101090023]BBL SA 080-0-13061-9 CA 080-3-00339-1 พลังงานลม,1101090023,bale[1101090023],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101090024,188,[1101090024]BBL SA 080-0-13064-3 CA 080-3-00340-9 อัตราค่าไฟฟ้า,1101090024,bale[1101090024],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101090025,189,[1101090025]BBL SA 080-0-13121-1 CA 080-3-00342-5 One year project,1101090025,bale[1101090025],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101090026,190,[1101090026]BBL SA 080-0-13126-0 CA 080-3-00344-1 มิวเทอร์ม-เฟสเซอซ์,1101090026,bale[1101090026],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101090027,191,[1101090027]BBL SA 080-0-13136-9 CA 080-3-00345-8 รถโดยสารประจำทาง,1101090027,bale[1101090027],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101090028,192,[1101090028]KTB SA 475-3-31857-5 CA 475-6-00579-9 เศรษฐกิจดิจิทัล,1101090028,bale[1101090028],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101090029,193,[1101090029]KTB SA 475-3-31978-4 CA 475-6-00581-0 เศรษฐกิจดิจิทัล (MP-61-0006),1101090029,bale[1101090029],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101090030,194,[1101090030]KTB SA 475-3-32354-4 CA 475-6-00599-3 สวทช.เงินนอกงบประมาณ,1101090030,bale[1101090030],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101090031,195,[1101090031]BBL SA 080-0-13325-8 CA 080-3-00356-5 ทดสอบซอฟต์แวร์ ,1101090031,bale[1101090031],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101090032,196,[1101090032]KTB SA 475-3-32462-1 CA 475-6-00600-0 เศรษฐกิจดิจิทัล (SP-62-0053),1101090032,bale[1101090032],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101090033,197,[1101090033]KTB SA 475-3-32464-8 CA 475-6-00601-9 เศรษฐกิจดิจิทัล (SP-62-0054),1101090033,bale[1101090033],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101090034,198,[1101090034]BBL SA 080-0-13350-6 CA 080-3-00358-1 อาหารฟังก์ชั่น,1101090034,bale[1101090034],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101090035,199,[1101090035]KTB SA 475-3-42387-5 CA 475-6-00633-7 MalHivPOCTs,1101090035,bale[1101090035],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101090036,200,[1101090036]KTB SA 475-3-42404-9 CA 475-6-00634-5 เซลล์ Vero และ MDCK,1101090036,bale[1101090036],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101090037,201,[1101090037]KTB SA 475-3-42406-5 CA 475-6-00635-3 เพาะปลูกกัญชา,1101090037,bale[1101090037],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1101099990,202,[1101099990]เงินฝากธนาคารที่มีวัตถุประสงค์เฉพาะ Interface,1101099990,bale[1101099990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1102010000,203,[1102010000]ลูกหนี้การค้า,1102010000,bale[1102010000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1102010001,204,[1102010001]ลูกหนี้การค้า - ในประเทศ หน่วยงานภาครัฐ,1102010001,bale[1102010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1102010002,205,[1102010002]ลูกหนี้การค้า - ในประเทศ หน่วยงานเอกชน,1102010002,bale[1102010002],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1102010003,206,[1102010003]ลูกหนี้การค้า - ต่างประเทศ,1102010003,bale[1102010003],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1102010004,207,[1102010004]ลูกหนี้อยู่ระหว่างดำเนินคดี,1102010004,bale[1102010004],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1102010005,208,[1102010005]ลูกหนี้ผ่อนชำระ,1102010005,bale[1102010005],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1102010006,209,[1102010006]ลูกหนี้เงินให้กู้ระยะยาว - CD,1102010006,bale[1102010006],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1102019990,210,[1102019990]ลูกหนี้การค้า - ในประเทศ หน่วยงานภาครัฐ Interface,1102019990,bale[1102019990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1102019991,211,[1102019991]ลูกหนี้การค้า - ในประเทศ หน่วยงานเอกชน Interface,1102019991,bale[1102019991],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1102019992,212,[1102019992]ลูกหนี้การค้า - ต่างประเทศ Interface,1102019992,bale[1102019992],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1102019993,213,[1102019993]ลูกหนี้อยู่ระหว่างดำเนินคดี Interface,1102019993,bale[1102019993],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1102019994,214,[1102019994]ลูกหนี้ผ่อนชำระ Interface,1102019994,bale[1102019994],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1103010000,215,[1103010000]ค่าเผื่อหนี้สงสัยจะสูญ,1103010000,bale[1103010000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1103010001,216,[1103010001]ค่าเผื่อหนี้สงสัยจะสูญ,1103010001,bale[1103010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1103019990,217,[1103019990]ค่าเผื่อหนี้สงสัยจะสูญ Interface,1103019990,bale[1103019990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1104010000,218,[1104010000]เงินยืมทดรองจ่ายให้พนักงาน,1104010000,bale[1104010000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1104010001,219,[1104010001]เงินยืมทดรองจ่าย,1104010001,bale[1104010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1104019990,220,[1104019990]เงินยืมทดรองจ่าย Interface,1104019990,bale[1104019990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1105010000,221,[1105010000]วัสดุคงเหลือ,1105010000,bale[1105010000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1105010001,222,[1105010001]วัสดุสำนักงาน,1105010001,bale[1105010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1105010002,223,[1105010002]วัสดุโฆษณาและเผยแพร่,1105010002,bale[1105010002],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1105010003,224,[1105010003]วัสดุงานบ้านและงานครัว,1105010003,bale[1105010003],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1105010004,225,[1105010004]วัสดุหนังสือ วารสาร และตำรา,1105010004,bale[1105010004],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1105010005,226,[1105010005]วัสดุวิทยาศาสตร์,1105010005,bale[1105010005],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1105010006,227,[1105010006]วัสดุคอมพิวเตอร์,1105010006,bale[1105010006],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1105010007,228,[1105010007]วัสดุไฟฟ้าและวิทยุ,1105010007,bale[1105010007],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1105010008,229,[1105010008]วัสดุอุปกรณ์ทางการแพทย์,1105010008,bale[1105010008],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1105010009,230,[1105010009]วัสดุกีฬา/ดนตรีนาฎศิลป์,1105010009,bale[1105010009],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1105010010,231,[1105010010]วัสดุงานวิจัยต้นแบบ,1105010010,bale[1105010010],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1105010011,232,[1105010011]พักโอนเข้าวัสดุคงเหลือจากการ Settlement I/O,1105010011,bale[1105010011],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1105019990,233,[1105019990]วัสดุคงเหลือ-Interface,1105019990,bale[1105019990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1106010000,234,[1106010000]ค่าใช้จ่ายล่วงหน้า,1106010000,bale[1106010000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1106010001,235,[1106010001]ค่าเช่าจ่ายล่วงหน้า,1106010001,bale[1106010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1106010002,236,[1106010002]ค่าประกันภัยจ่ายล่วงหน้า,1106010002,bale[1106010002],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1106019991,237,[1106019991]ค่าประกันจ่ายล่วงหน้า Interface,1106019991,bale[1106019991],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1106010003,238,[1106010003]ค่าสมาชิก หนังสือและวารสารจ่ายล่วงหน้า,1106010003,bale[1106010003],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1106019992,239,[1106019992]ค่าสมาชิก/หนังสือและวารสารจ่ายล่วงหน้า Interface,1106019992,bale[1106019992],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1106010004,240,[1106010004]ค่าลิขสิทธ์จ่ายล่วงหน้า,1106010004,bale[1106010004],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1106019993,241,[1106019993]ค่าลิขสิทธ์จ่ายล่วงหน้า Interface,1106019993,bale[1106019993],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1106010005,242,[1106010005]ค่า AUC จ่ายล่วงหน้า,1106010005,bale[1106010005],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1106010006,243,[1106010006]ค่า AIT จ่ายล่วงหน้า,1106010006,bale[1106010006],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1106019995,244,[1106019995]ค่า AIT จ่ายล่วงหน้า Interface,1106019995,bale[1106019995],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1106019994,245,[1106019994]ค่า AUC จ่ายล่วงหน้า Interface,1106019994,bale[1106019994],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1106010007,246,[1106010007]ค่าใช้จ่ายจ่ายล่วงหน้าอื่น,1106010007,bale[1106010007],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1106019996,247,[1106019996]ค่าใช้จ่ายจ่ายล่วงหน้าอื่น Interface,1106019996,bale[1106019996],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1106010008,248,[1106010008]เงินจ่ายล่วงหน้าอื่น,1106010008,bale[1106010008],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1106019997,249,[1106019997]เงินจ่ายล่วงหน้าอื่น Interface,1106019997,bale[1106019997],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1106019990,250,[1106019990]ค่าเช่าจ่ายล่วงหน้า Interface,1106019990,bale[1106019990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1107010000,251,[1107010000]เงินอุดหนุนจากงบประมาณแผ่นดินค้างรับ,1107010000,bale[1107010000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1107010001,252,[1107010001]เงินอุดหนุนจากงบประมาณแผ่นดินค้างรับ-อุดหนุนเฉพาะกิจ,1107010001,bale[1107010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1107010090,253,[1107010090]เงินอุดหนุนจากงบประมาณแผ่นดินค้างรับ Interface,1107010090,bale[1107010090],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1107010002,254,[1107010002]เงินอุดหนุนจากงบประมาณแผ่นดินค้างรับ-อุดหนุนทั่วไป,1107010002,bale[1107010002],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1108010000,255,[1108010000]ดอกเบี้ยค้างรับ,1108010000,bale[1108010000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1108010001,256,[1108010001]ดอกเบี้ยค้างรับ,1108010001,bale[1108010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1108010090,257,[1108010090]ดอกเบี้ยค้างรับ Interface,1108010090,bale[1108010090],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1109010000,258,[1109010000]ภาษีมูลค่าเพิ่ม,1109010000,bale[1109010000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1109010001,259,[1109010001]ภาษีซื้อ,1109010001,bale[1109010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1109010002,260,[1109010002]ภาษีมูลค่าเพิ่ม,1109010002,bale[1109010002],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1109010003,261,[1109010003]พักภาษีซื้อ,1109010003,bale[1109010003],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1109010090,262,[1109010090]พักภาษีซื้อ Interface,1109010090,bale[1109010090],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1190000000,263,[1190000000]สินทรัพย์หมุนเวียนอื่น,1190000000,bale[1190000000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1190010000,264,[1190010000]ลูกหนี้อื่น,1190010000,bale[1190010000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1190010001,265,[1190010001]ลูกหนี้หน่วยบริการ,1190010001,bale[1190010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1190019990,266,[1190019990]ลูกหนี้หน่วยบริการ Interface,1190019990,bale[1190019990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1190010002,267,[1190010002]เงินรอรับรู้ - ส/ท,1190010002,bale[1190010002],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1190019900,268,[1190019900]ลูกหนี้อื่น,1190019900,bale[1190019900],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1190019991,269,[1190019991]ลูกหนี้อื่น ๆ Interface,1190019991,bale[1190019991],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1190900000,270,[1190900000]สินทรัพย์หมุนเวียนอื่น,1190900000,bale[1190900000],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1190909900,271,[1190909900]สินทรัพย์หมุนเวียนอื่น,1190909900,bale[1190909900],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1200000000,272,[1200000000]สินทรัพย์ไม่หมุนเวียน,1200000000,bale[1200000000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1201000000,273,[1201000000]เงินฝากธนาคารประจำ มากกว่า 3 เดือน,1201000000,bale[1201000000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1201010000,274,[1201010000]เงินฝากธนาคาร-ประจำ มากกว่า 3-12 เดือน,1201010000,bale[1201010000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1201010001,275,[1201010001]BBL FA 942-6-00007-2 สวทช.[12 เดือน],1201010001,bale[1201010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1201010002,276,[1201010002]BBL FA 080-2-01142-9 [4 เดือน],1201010002,bale[1201010002],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1201010003,277,[1201010003]BBL FA 080-2-01363-1 (10 เดือน),1201010003,bale[1201010003],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1201010004,278,[1201010004]TNC FA 482-1-10949-7 (6 เดือน),1201010004,bale[1201010004],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1201010005,279,[1201010005]เงินโอนระหว่างธนาคาร,1201010005,bale[1201010005],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1201019990,280,[1201019990]เงินฝากธนาคาร-ประจำ มากกว่า 3-12 เดือน Interface,1201019990,bale[1201019990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1201020000,281,[1201020000]เงินฝากธนาคาร-ประจำเกิน 1 ปี,1201020000,bale[1201020000],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1201029990,282,[1201029990]เงินฝากธนาคาร-ประจำเกิน 1 ปี ธนาคารรัฐ Interface,1201029990,bale[1201029990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1202000000,283,[1202000000]เงินให้กู้ระยะยาว,1202000000,bale[1202000000],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1202019900,284,[1202019900]เงินให้กู้ระยะยาวอื่น,1202019900,bale[1202019900],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1203000000,285,[1203000000]เงินลงทุนระยะยาว,1203000000,bale[1203000000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1203010000,286,[1203010000]เงินลงทุนในบริษัท จำกัด สุทธิ,1203010000,bale[1203010000],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1203010001,287,[1203010001]เงินลงทุนในบริษัทจำกัด,1203010001,bale[1203010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1203010002,288,[1203010002]ปรับมูลค่าเงินลงทุนในบริษัทจำกัด,1203010002,bale[1203010002],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1203010003,289,[1203010003]ค่าเผื่อการด้อยค่า-เงินลงทุนในบริษัทจำกัด,1203010003,bale[1203010003],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1203900000,290,[1203900000]เงินลงทุนระยะยาวอื่น,1203900000,bale[1203900000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1203900001,291,[1203900001]เงินลงทุนระยะยาว,1203900001,bale[1203900001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1203900002,292,[1203900002]ปรับมูลค่าเงินลงทุนระยะยาว,1203900002,bale[1203900002],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1203900003,293,[1203900003]ค่าเผื่อการด้อยค่า-เงินลงทุนระยะยาว,1203900003,bale[1203900003],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1203909990,294,[1203909990]ค่าเผื่อการด้อยค่า-เงินลงทุนระยะยาว Interface,1203909990,bale[1203909990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1203900004,295,[1203900004]เงินลงทุนเผื่อขาย,1203900004,bale[1203900004],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1203909991,296,[1203909991]เงินลงทุนเผื่อขาย Interface,1203909991,bale[1203909991],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1204000000,297,[1204000000]เงินร่วมลงทุน,1204000000,bale[1204000000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1204010001,298,[1204010001]เงินลงทุนหน่วยบริการ,1204010001,bale[1204010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1204019990,299,[1204019990]เงินลงทุนหน่วยบริการ Interface,1204019990,bale[1204019990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1205000000,300,[1205000000]เงินค้ำประกันจ่าย,1205000000,bale[1205000000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1205010001,301,[1205010001]เงินค้ำประกันสัญญา,1205010001,bale[1205010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1205010002,302,[1205010002]เงินค้ำประกันผลงาน,1205010002,bale[1205010002],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1205019990,303,[1205019990]เงินค้ำประกันสัญญา Interface,1205019990,bale[1205019990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1205019991,304,[1205019991]เงินค้ำประกันผลงาน Interface,1205019991,bale[1205019991],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1206000000,305,[1206000000]เงินมัดจำ,1206000000,bale[1206000000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1206010001,306,[1206010001]เงินมัดจำ-ค่าเช่าอาคาร ค่าบริการ,1206010001,bale[1206010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1206010002,307,[1206010002]เงินมัดจำ-ค่าโทรศัพท์,1206010002,bale[1206010002],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1206010003,308,[1206010003]เงินมัดจำ-อื่น,1206010003,bale[1206010003],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1206019990,309,[1206019990]เงินมัดจำ-ค่าเช่าอาคาร/ค่าบริการ Interface,1206019990,bale[1206019990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1206019991,310,[1206019991]เงินมัดจำ-ค่าโทรศัพท์ Interface,1206019991,bale[1206019991],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1206019992,311,[1206019992]เงินมัดจำ-อื่น Interface,1206019992,bale[1206019992],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1207000000,312,[1207000000]อสังหาริมทรัยพ์เพื่อการลงทุน,1207000000,bale[1207000000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1207010000,313,[1207010000]อาคาร/ส่วนปรับปรุงอาคารเพื่อการลงทุน,1207010000,bale[1207010000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1207010001,314,[1207010001]อาคารเพื่อการลงทุน,1207010001,bale[1207010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1207010002,315,[1207010002]ส่วนปรับปรุงอาคารเพื่อการลงทุน,1207010002,bale[1207010002],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1207019990,316,[1207019990]อาคารเพื่อการลงทุน Interface,1207019990,bale[1207019990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1207019991,317,[1207019991]ส่วนปรับปรุงอาคารเพื่อการลงทุน Interface,1207019991,bale[1207019991],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1208000000,318,[1208000000]ที่ดิน อาคารและครุภัณฑ์,1208000000,bale[1208000000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1208010000,319,[1208010000]ที่ดิน/ส่วนปรับปรุงที่ดิน,1208010000,bale[1208010000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1208010001,320,[1208010001]ที่ดิน,1208010001,bale[1208010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1208010002,321,[1208010002]ส่วนปรับปรุงที่ดิน,1208010002,bale[1208010002],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1208019990,322,[1208019990]ที่ดิน Interface,1208019990,bale[1208019990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1208019991,323,[1208019991]ส่วนปรับปรุงที่ดิน Interface,1208019991,bale[1208019991],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1208020000,324,[1208020000]อาคาร/ส่วนปรับปรุอาคาร,1208020000,bale[1208020000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1208020001,325,[1208020001]อาคาร,1208020001,bale[1208020001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1208020002,326,[1208020002]อาคารชั่วคราว,1208020002,bale[1208020002],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1208020003,327,[1208020003]สิ่งปลูกสร้าง,1208020003,bale[1208020003],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1208020004,328,[1208020004]ส่วนปรับปรุงอาคาร,1208020004,bale[1208020004],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1208029990,329,[1208029990]อาคาร Interface,1208029990,bale[1208029990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1208029991,330,[1208029991]อาคารชั่วคราว Interface,1208029991,bale[1208029991],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1208029992,331,[1208029992]สิ่งปลูกสร้าง Interface,1208029992,bale[1208029992],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1208029993,332,[1208029993]ส่วนปรับปรุงอาคาร Interface,1208029993,bale[1208029993],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1208030000,333,[1208030000]ครุภัณฑ์,1208030000,bale[1208030000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1208030001,334,[1208030001]ครุภัณฑ์และอุปกรณ์สำนักงาน,1208030001,bale[1208030001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1208030002,335,[1208030002]ครุภัณฑ์และอุปกรณ์วิทยาศาสตร์,1208030002,bale[1208030002],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1208030003,336,[1208030003]ครุภัณฑ์และอุปกรณ์โฆษณาและเผยแพร่,1208030003,bale[1208030003],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1208030004,337,[1208030004]ครุภัณฑ์และอุปกรณ์ไฟฟ้าและวิทยุ,1208030004,bale[1208030004],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1208030005,338,[1208030005]ครุภัณฑ์และอุปกรณ์คอมพิวเตอร์,1208030005,bale[1208030005],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1208030006,339,[1208030006]ครุภัณฑ์และอุปกรณ์งานบ้านงานครัว,1208030006,bale[1208030006],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1208030007,340,[1208030007]ครุภัณฑ์และอุปกรณ์การแพทย์,1208030007,bale[1208030007],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1208030008,341,[1208030008]ครุภัณฑ์และอุปกรณ์การเกษตร,1208030008,bale[1208030008],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1208030009,342,[1208030009]ครุภัณฑ์และอุปกรณ์กีฬา/ดนตรีนาฏศิลป์,1208030009,bale[1208030009],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1208030010,343,[1208030010]ครุภัณฑ์และอุปกรณ์ก่อสร้าง,1208030010,bale[1208030010],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1208039990,344,[1208039990]ครุภัณฑ์และอุปกรณ์สำนักงาน Interface,1208039990,bale[1208039990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1208039991,345,[1208039991]ครุภัณฑ์และอุปกรณ์วิทยาศาสตร์ Interface,1208039991,bale[1208039991],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1208039992,346,[1208039992]ครุภัณฑ์และอุปกรณ์โฆษณาและเผยแพร่ Interface,1208039992,bale[1208039992],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1208039993,347,[1208039993]ครุภัณฑ์และอุปกรณ์ไฟฟ้าและวิทยุ Interface,1208039993,bale[1208039993],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1208039994,348,[1208039994]ครุภัณฑ์และอุปกรณ์คอมพิวเตอร์ Interface,1208039994,bale[1208039994],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1208039995,349,[1208039995]ครุภัณฑ์และอุปกรณ์งานบ้านงานครัว Interface,1208039995,bale[1208039995],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1208039996,350,[1208039996]ครุภัณฑ์และอุปกรณ์การแพทย์ Interface,1208039996,bale[1208039996],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1208039997,351,[1208039997]ครุภัณฑ์และอุปกรณ์การเกษตร Interface,1208039997,bale[1208039997],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1208039998,352,[1208039998]ครุภัณฑ์และอุปกรณ์กีฬา/ดนตรีนาฏศิลป์ Interface,1208039998,bale[1208039998],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1208039999,353,[1208039999]ครุภัณฑ์และอุปกรณ์ก่อสร้าง Interface,1208039999,bale[1208039999],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1209000000,354,[1209000000]ยานพาหนะ,1209000000,bale[1209000000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1209010000,355,[1209010000]ยานพาหนะ,1209010000,bale[1209010000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1209010001,356,[1209010001]ยานพาหนะ,1209010001,bale[1209010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1209019990,357,[1209019990]ยานพาหนะ-Interface,1209019990,bale[1209019990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1210000000,358,[1210000000]สินทรัพย์ไม่มีตัวตน,1210000000,bale[1210000000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1210010000,359,[1210010000]สินทรัพย์ไม่มีตัวตน,1210010000,bale[1210010000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1210010001,360,[1210010001]สินทรัพย์ไม่มีตัวตน,1210010001,bale[1210010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1210019990,361,[1210019990]สินทรัพย์ไม่มีตัวตน Interface,1210019990,bale[1210019990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1211000000,362,[1211000000]สินทรัพย์ตามสัญญาเช่าการเงิน,1211000000,bale[1211000000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1211010000,363,[1211010000]สินทรัพย์ตามสัญญาเช่าการเงิน,1211010000,bale[1211010000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1211010001,364,[1211010001]สินทรัพย์ตามสัญญาเช่าการเงิน,1211010001,bale[1211010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1211019990,365,[1211019990]สินทรัพย์ตามสัญญาเช่าการเงิน Interface,1211019990,bale[1211019990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212000000,366,[1212000000]ค่าเสื่อมราคาสะสม,1212000000,bale[1212000000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212010000,367,[1212010000]ค่าเสื่อมสะสม-อาคาร/ส่วนปรับปรุงอาคารเพื่อการลงทุน,1212010000,bale[1212010000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212010001,368,[1212010001]ค่าเสื่อมสะสม-อาคารเพื่อการลงทุน,1212010001,bale[1212010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212010002,369,[1212010002]ค่าเสื่อมสะสม-ส่วนปรับปรุงอาคารเพื่อการลงทุน,1212010002,bale[1212010002],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212019990,370,[1212019990]ค่าเสื่อมสะสม-อาคารเพื่อการลงทุน Interface,1212019990,bale[1212019990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212019991,371,[1212019991]ค่าเสื่อมสะสม-ส่วนปรับปรุงอาคารเพื่อการลงทุน Interface,1212019991,bale[1212019991],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212020000,372,[1212020000]ค่าเสื่อมสะสม-ส่วนปรับปรุงที่ดิน,1212020000,bale[1212020000],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212020001,373,[1212020001]ค่าเสื่อมสะสม-ส่วนปรับปรุงที่ดิน,1212020001,bale[1212020001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212029990,374,[1212029990]ค่าเสื่อมสะสม-ส่วนปรับปรุงที่ดิน Interface,1212029990,bale[1212029990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212030000,375,[1212030000]ค่าเสื่อมสะสม-อาคาร/ส่วนปรับปรุงอาคาร,1212030000,bale[1212030000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212030001,376,[1212030001]ค่าเสื่อมสะสม-อาคาร,1212030001,bale[1212030001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212030002,377,[1212030002]ค่าเสื่อมสะสม-อาคารชั่วคราว,1212030002,bale[1212030002],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212030003,378,[1212030003]ค่าเสื่อมสะสม-สิ่งปลูกสร้าง,1212030003,bale[1212030003],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212030004,379,[1212030004]ค่าเสื่อมสะสม-ส่วนปรับปรุงอาคาร,1212030004,bale[1212030004],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212039990,380,[1212039990]ค่าเสื่อมสะสม-อาคาร Interface,1212039990,bale[1212039990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212039991,381,[1212039991]ค่าเสื่อมสะสม-อาคารชั่วคราว Interface,1212039991,bale[1212039991],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212039992,382,[1212039992]ค่าเสื่อมสะสม-สิ่งปลูกสร้าง Interface,1212039992,bale[1212039992],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212039993,383,[1212039993]ค่าเสื่อมสะสม-ส่วนปรับปรุงอาคาร Interface,1212039993,bale[1212039993],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212040000,384,[1212040000]ค่าเสื่อมสะสม-ครุภัณฑ์,1212040000,bale[1212040000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212040001,385,[1212040001]ค่าเสื่อมสะสม-ครุภัณฑ์สำนักงาน,1212040001,bale[1212040001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212040002,386,[1212040002]ค่าเสื่อมสะสม-ครุภัณฑ์วิทยาศาสตร์,1212040002,bale[1212040002],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212040003,387,[1212040003]ค่าเสื่อมสะสม-ครุภัณฑ์โฆษณาและเผยแพร่,1212040003,bale[1212040003],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212040004,388,[1212040004]ค่าเสื่อมสะสม-ครุภัณฑ์ไฟฟ้าและวิทยุ,1212040004,bale[1212040004],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212040005,389,[1212040005]ค่าเสื่อมสะสม-ครุภัณฑ์คอมพิวเตอร์,1212040005,bale[1212040005],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212040006,390,[1212040006]ค่าเสื่อมสะสม-ครุภัณฑ์งานบ้านงานครัว,1212040006,bale[1212040006],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212040007,391,[1212040007]ค่าเสื่อมสะสม-ครุภัณฑ์การแพทย์,1212040007,bale[1212040007],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212040008,392,[1212040008]ค่าเสื่อมสะสม-ครุภัณฑ์การเกษตร,1212040008,bale[1212040008],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212040009,393,[1212040009]ค่าเสื่อมสะสม-ครุภัณฑ์กีฬา/ดนตรี-นาฏศิลป์,1212040009,bale[1212040009],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212040010,394,[1212040010]ค่าเสื่อมสะสม-ครุภัณฑ์และอุปกรณ์ก่อสร้าง,1212040010,bale[1212040010],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212049990,395,[1212049990]ค่าเสื่อมสะสม-ครุภัณฑ์สำนักงาน Interface,1212049990,bale[1212049990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212049991,396,[1212049991]ค่าเสื่อมสะสม-ครุภัณฑ์วิทยาศาสตร์ Interface,1212049991,bale[1212049991],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212049992,397,[1212049992]ค่าเสื่อมสะสม-ครุภัณฑ์โฆษณาและเผยแพร่ Interface,1212049992,bale[1212049992],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212049993,398,[1212049993]ค่าเสื่อมสะสม-ครุภัณฑ์ไฟฟ้าและวิทยุ Interface,1212049993,bale[1212049993],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212049994,399,[1212049994]ค่าเสื่อมสะสม-ครุภัณฑ์คอมพิวเตอร์ Interface,1212049994,bale[1212049994],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212049995,400,[1212049995]ค่าเสื่อมสะสม-ครุภัณฑ์งานบ้านงานครัว Interface,1212049995,bale[1212049995],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212049996,401,[1212049996]ค่าเสื่อมสะสม-ครุภัณฑ์การแพทย์ Interface,1212049996,bale[1212049996],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212049997,402,[1212049997]ค่าเสื่อมสะสม-ครุภัณฑ์การเกษตร Interface,1212049997,bale[1212049997],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212049998,403,[1212049998]ค่าเสื่อมสะสม-ครุภัณฑ์กีฬา/ดนตรี-นาฏศิลป์ Interface,1212049998,bale[1212049998],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212049999,404,[1212049999]ค่าเสื่อมสะสม-ครุภัณฑ์และอุปกรณ์ก่อสร้าง Interface,1212049999,bale[1212049999],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212050000,405,[1212050000]ค่าเสื่อมสะสม-ยานพาหนะ,1212050000,bale[1212050000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212050001,406,[1212050001]ค่าเสื่อมสะสม-ยานพาหนะ,1212050001,bale[1212050001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212059990,407,[1212059990]ค่าเสื่อมสะสม-ยานพาหนะ Interface,1212059990,bale[1212059990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212060000,408,[1212060000]ค่าตัดจำหน่ายสะสม-สินทรัพย์ไม่มีตัวตน,1212060000,bale[1212060000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212060001,409,[1212060001]ค่าตัดจำหน่ายสะสม-สินทรัพย์ไม่มีตัวตน,1212060001,bale[1212060001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212069990,410,[1212069990]ค่าตัดจำหน่ายสะสม-สินทรัพย์ไม่มีตัวตน Interface,1212069990,bale[1212069990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212070000,411,[1212070000]ค่าเสื่อมราคาสะสม-สินทรัพย์ตามสัญญาเช่าการเงิน,1212070000,bale[1212070000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1212070001,412,[1212070001]ค่าเสื่อมราคาสะสม-สินทรัพย์ตามสัญญาเช่าการเงิน,1212070001,bale[1212070001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1213000000,413,[1213000000]สินทรัพย์ระหว่างก่อสร้าง,1213000000,bale[1213000000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1213010001,414,[1213010001]สินทรัพย์ระหว่างก่อสร้าง-อาคาร,1213010001,bale[1213010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1213010002,415,[1213010002]สินทรัพย์ระหว่างก่อสร้าง-ค่าควบคุมงาน,1213010002,bale[1213010002],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1213010003,416,[1213010003]สินทรัพย์ระหว่างก่อสร้าง-ค่าออกแบบอาคาร,1213010003,bale[1213010003],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1213010004,417,[1213010004]สินทรัพย์ระหว่างก่อสร้าง-ครุภัณฑ์อื่นๆ,1213010004,bale[1213010004],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1213019990,418,[1213019990]สินทรัพย์ระหว่างก่อสร้าง-อาคาร Interface,1213019990,bale[1213019990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1213019991,419,[1213019991]สินทรัพย์ระหว่างก่อสร้าง-ค่าควบคุมงาน Interface,1213019991,bale[1213019991],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1213019992,420,[1213019992]สินทรัพย์ระหว่างก่อสร้าง-ค่าออกแบบอาคาร Interface,1213019992,bale[1213019992],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1213019993,421,[1213019993]สินทรัพย์ระหว่างก่อสร้าง-ติดตั้งเครื่องจักร Interface,1213019993,bale[1213019993],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1214000000,422,[1214000000]สินทรัพย์ระหว่างทาง,1214000000,bale[1214000000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1214010001,423,[1214010001]สินทรัพย์ระหว่างทาง,1214010001,bale[1214010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1214010002,424,[1214010002]พักครุภัณฑ์,1214010002,bale[1214010002],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1214010003,425,[1214010003]Down payment พักครุภัณฑ์,1214010003,bale[1214010003],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1214010004,426,[1214010004]Clearing down payment พักครุภัณฑ์,1214010004,bale[1214010004],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1214010005,427,[1214010005]ค่าเสื่อมสะสม-พักครุภัณฑ์,1214010005,bale[1214010005],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1214019990,428,[1214019990]สินทรัพย์ระหว่างทาง-INTERFACE,1214019990,bale[1214019990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1290000000,429,[1290000000]สินทรัพย์ไม่หมุนเวียนอื่น,1290000000,bale[1290000000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th1290010001,430,[1290010001]เงินกู้ยืมพนักงานผู้ประสบภัยธรรมชาติ,1290010001,bale[1290010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1290010002,431,[1290010002]ลูกหนี้ระหว่างบังคับคดี,1290010002,bale[1290010002],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1290010003,432,[1290010003]ดอกเบี้ยจ่ายรอการรับรู้,1290010003,bale[1290010003],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1290019990,433,[1290019990]ลูกหนี้ระหว่างรอบังคับคดี Interface,1290019990,bale[1290019990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th1290019900,434,[1290019900]สินทรัพย์ไม่หมุนเวียนอื่น,1290019900,bale[1290019900],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2000000000,435,[2000000000]หนี้สิน,2000000000,bale[2000000000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th2100000000,436,[2100000000]หนี้สินหมุนเวียน,2100000000,bale[2100000000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th2101010000,437,[2101010000]เจ้าหนี้การค้า,2101010000,bale[2101010000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th2101010001,438,[2101010001]เจ้าหนี้การค้า - ในประเทศ,2101010001,bale[2101010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2101010002,439,[2101010002]เจ้าหนี้การค้า - ต่างประเทศ,2101010002,bale[2101010002],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2101010003,440,[2101010003]GR-IR (เจ้าหนี้การค้า),2101010003,bale[2101010003],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2101010004,441,[2101010004]เจ้าหนี้ฝากขายหนังสือ (Consignment),2101010004,bale[2101010004],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2101019990,442,[2101019990]เจ้าหนี้การค้า-ในประเทศ Interface,2101019990,bale[2101019990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2101019991,443,[2101019991]เจ้าหนี้การค้า-ต่างประเทศ Interface,2101019991,bale[2101019991],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2102010000,444,[2102010000]เจ้าหนี้อื่น,2102010000,bale[2102010000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th2102010001,445,[2102010001]เจ้าหนี้หน่วยบริการ,2102010001,bale[2102010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2102019992,446,[2102019992]เจ้าหนี้อื่น Interface,2102019992,bale[2102019992],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2102010002,447,[2102010002]เงินรอรับรู้,2102010002,bale[2102010002],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2102019991,448,[2102019991]เงินรอรับรู้ Interface,2102019991,bale[2102019991],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2102019900,449,[2102019900]เจ้าหนี้อื่น,2102019900,bale[2102019900],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2102019990,450,[2102019990]เจ้าหนี้หน่วยบริการ Interface,2102019990,bale[2102019990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2103010000,451,[2103010000]ค่าใช้จ่ายค้างจ่าย,2103010000,bale[2103010000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th2103010001,452,[2103010001]ค่าใช้จ่ายค้างจ่าย,2103010001,bale[2103010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2103019990,453,[2103019990]ค่าใช้จ่ายค้างจ่าย Interface,2103019990,bale[2103019990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2104010000,454,[2104010000]รายได้รับล่วงหน้า,2104010000,bale[2104010000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th2104010001,455,[2104010001]รายได้รับล่วงหน้า,2104010001,bale[2104010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2104019990,456,[2104019990]รายได้รับล่วงหน้า Interface,2104019990,bale[2104019990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2105010000,457,[2105010000]เงินค้างนำส่ง,2105010000,bale[2105010000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th2105010001,458,[2105010001]เงินกองทุนสำรองเลี้ยงชีพ,2105010001,bale[2105010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2105010002,459,[2105010002]ภาษีเงินได้บุคคลธรรมดาหัก ณ ที่จ่าย,2105010002,bale[2105010002],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2105010003,460,[2105010003]ภาษีเงินได้นิติบุคคลหัก ณ ที่จ่าย,2105010003,bale[2105010003],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2106010000,461,[2106010000]ภาษีขาย,2106010000,bale[2106010000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th2106010001,462,[2106010001]ภาษีขาย,2106010001,bale[2106010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2106010002,463,[2106010002]พักภาษีขาย,2106010002,bale[2106010002],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2106019990,464,[2106019990]พักภาษีขาย Interface,2106019990,bale[2106019990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2107010000,465,[2107010000]เงินงบประมาณกันเบิกเหลื่อมปี,2107010000,bale[2107010000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th2107010001,466,[2107010001]เงินงบประมาณกันเบิกเหลื่อมปี,2107010001,bale[2107010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2107019990,467,[2107019990]เงินงบประมาณกันเบิกเหลื่อมปี Interface,2107019990,bale[2107019990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2190010000,468,[2190010000]หนี้สินหมุนเวียนอื่น,2190010000,bale[2190010000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th2190010001,469,[2190010001]รายได้รอการรับรู้,2190010001,bale[2190010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2190019990,470,[2190019990]รายได้รอการรับรู้ Interface,2190019990,bale[2190019990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2190019900,471,[2190019900]หนี้สินหมุนเวียนอื่น,2190019900,bale[2190019900],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2200000000,472,[2200000000]หนี้สินไม่หมุนเวียน,2200000000,bale[2200000000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th2201010000,473,[2201010000]เงินสำรองรอจ่าย,2201010000,bale[2201010000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th2201010001,474,[2201010001]เงินบำเหน็จพนักงาน สวทช. รอจ่าย,2201010001,bale[2201010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2201019990,475,[2201019990]เงินบำเหน็จพนักงาน สวทช. รอจ่าย Interface,2201019990,bale[2201019990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2201010002,476,[2201010002]เงินค่าสมนาคุณ สวทช. รอจ่าย,2201010002,bale[2201010002],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2201019991,477,[2201019991]เงินค่าสมนาคุณ สวทช. รอจ่าย Interface,2201019991,bale[2201019991],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2202010000,478,[2202010000]หนี้สินตามสัญญาเช่าการเงิน,2202010000,bale[2202010000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th2202010001,479,[2202010001]หนี้สินตามสัญญาเช่าการเงิน,2202010001,bale[2202010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2202019990,480,[2202019990]หนี้สินตามสัญญาเช่าการเงิน Interface,2202019990,bale[2202019990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2203010000,481,[2203010000]เงินมัดจำ/เงินค้ำประกัน,2203010000,bale[2203010000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th2203010001,482,[2203010001]เงินมัดจำรับ-ค่าเช่าสำนักงาน,2203010001,bale[2203010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2203019990,483,[2203019990]เงินมัดจำรับ-ค่าเช่าสำนักงาน Interface,2203019990,bale[2203019990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2203010002,484,[2203010002]เงินมัดจำรับ-ค่าบริการส่วนกลาง,2203010002,bale[2203010002],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2203019991,485,[2203019991]เงินมัดจำรับ-ค่าบริการส่วนกลาง Interface,2203019991,bale[2203019991],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2203010003,486,[2203010003]เงินมัดจำรับ-ค่าตกแต่งพื้นที่,2203010003,bale[2203010003],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2203010004,487,[2203010004]เงินมัดจำรับ-ค่าเช่าป้าย,2203010004,bale[2203010004],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2203019993,488,[2203019993]เงินมัดจำรับ-ค่าเช่าป้าย Interface,2203019993,bale[2203019993],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2203010005,489,[2203010005]เงินมัดจำรับ-อื่น,2203010005,bale[2203010005],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2203019994,490,[2203019994]เงินมัดจำรับ-อื่น Interface,2203019994,bale[2203019994],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2203010006,491,[2203010006]เงินค้ำประกันรับ-สัญญา,2203010006,bale[2203010006],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2203010007,492,[2203010007]เงินค้ำประกันรับ-ผลงาน,2203010007,bale[2203010007],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2203010008,493,[2203010008]เงินค้ำประกันรับอื่น,2203010008,bale[2203010008],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2203019992,494,[2203019992]เงินมัดจำรับ-ค่าตกแต่งพื้นที่ Interface,2203019992,bale[2203019992],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2203019995,495,[2203019995]เงินค้ำประกันรับ-สัญญา Interface,2203019995,bale[2203019995],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2203019996,496,[2203019996]เงินค้ำประกันรับ-ผลงาน Interface,2203019996,bale[2203019996],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2203019997,497,[2203019997]เงินค้ำประกันรับอื่น Interface,2203019997,bale[2203019997],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2204010000,498,[2204010000]รายได้เงินอุดหนุนรอการรับรู้,2204010000,bale[2204010000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th2204010100,499,[2204010100]รายได้รอการรับรู้ - รอบังคับคดี,2204010100,bale[2204010100],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2204019990,500,[2204019990]รายได้รอการรับรู้ - รอบังคับคดี Interface,2204019990,bale[2204019990],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2290010000,501,[2290010000]หนี้สินไม่หมุนเวียนอื่น,2290010000,bale[2290010000],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th2290019900,502,[2290019900]หนี้สินไม่หมุนเวียนอื่น,2290019900,bale[2290019900],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th3000000000,503,[3000000000]เงินกองทุน (ส่วนของเจ้าของ),3000000000,bale[3000000000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th3101010000,504,[3101010000]ทุน,3101010000,bale[3101010000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th3101010001,505,[3101010001]ทุนประเดิมของ สวทช.,3101010001,bale[3101010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th3101010002,506,[3101010002]ทุนรับโอน-โครงการวิทยาศาสตร์และเทคโนโลยีฯ (STDB),3101010002,bale[3101010002],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th3101010003,507,[3101010003]ทุนรับโอน-สำนักงานปลัดกระทรวง กระทรวงวิทย์,3101010003,bale[3101010003],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th3101010004,508,[3101010004]ทุนรับโอน-สวทช.,3101010004,bale[3101010004],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th3101010005,509,[3101010005]ทุนรับโอน-NECTEC,3101010005,bale[3101010005],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th3101010006,510,[3101010006]ทุนรับโอนอื่น,3101010006,bale[3101010006],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th3101010007,511,[3101010007]ทุนที่โอนออก-สวทน.,3101010007,bale[3101010007],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th3101010008,512,[3101010008]ทุนที่โอนออก-ADTEC,3101010008,bale[3101010008],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th3101010009,513,[3101010009]ทุนที่โอนออกอื่น,3101010009,bale[3101010009],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th3101010010,514,[3101010010]ทุนรับโอนโครงการพิเศษทุนประเดิม,3101010010,bale[3101010010],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th3201010000,515,[3201010000]ส่วนเกินทุนจากการบริจาค,3201010000,bale[3201010000],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th3201010001,516,[3201010001]ส่วนเกินทุนจากการบริจาค,3201010001,bale[3201010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th3301010000,517,[3301010000]รายได้สูงกว่า(ต่ำกว่า)ค่าใช้จ่ายสะสม,3301010000,bale[3301010000],font-weight: bold,2,num,,,pct,mis_report_bs
+mis_report_bs_th3301010001,518,[3301010001]รายได้สูงกว่า (ต่ำกว่า) ค่าใช้จ่ายสะสม,3301010001,bale[3301010001],text-indent: 50px,2,num,,,pct,mis_report_bs
+mis_report_bs_th3301010002,519,[3301010002]กำไร/ขาดทุน ที่ยังไม่เกิดขึ้นในหลักทรัพย์เผื่อขาย,3301010002,bale[3301010002],text-indent: 50px,2,num,,,pct,mis_report_bs
+,,,,,,,,,,,
+mis_report_bs_internal_th1000000000,1,[1000000000]สินทรัพย์,1000000000,"bale[1000000000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1100000000,2,[1100000000]สินทรัพย์หมุนเวียน,1100000000,"bale[1100000000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101000000,3,[1101000000]เงินสดและรายการเทียบเท่าเงินสด,1101000000,"bale[1101000000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101010000,4,[1101010000]เงินสด,1101010000,"bale[1101010000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101010001,5,[1101010001]เงินสดย่อย,1101010001,"bale[1101010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101010002,6,[1101010002]เงินสดในมือ,1101010002,"bale[1101010002][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101010003,7,[1101010003]เช็ครับ,1101010003,"bale[1101010003][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101019990,8,[1101019990]เงินสดในมือ Interface,1101019990,"bale[1101019990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101020000,9,[1101020000]เงินฝากธนาคาร-ออมทรัพย์,1101020000,"bale[1101020000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101020001,10,[1101020001]KTB CA 152-6-00424-0 สวทช.-เงินในงบประมาณ,1101020001,"bale[1101020001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101020002,11,[1101020002]KTB CA 152-6-00426-7 สวทช.-เงินนอกงบประมาณ,1101020002,"bale[1101020002][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101020003,12,[1101020003]KTB CA 152-6-00469-0 สวทช.-เงินเบิกแทนกัน,1101020003,"bale[1101020003][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101020004,13,[1101020004]KTB SA 152-1-32668-1 CA 152-6-00244-2 สวทช.,1101020004,"bale[1101020004][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101020005,14,[1101020005]KTB SA 013-1-51385-0 CA 013-6-08136-3 สถาบันวิทยาการ,1101020005,"bale[1101020005][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101020006,15,[1101020006]KTB SA 152-1-32670-3 CA 152-6-00245-0 นักเรียนทุน,1101020006,"bale[1101020006][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101020007,16,[1101020007]BBL SA 080-0-00001-0 CA 080-3-00001-7 สวทช.,1101020007,"bale[1101020007][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101020008,17,[1101020008]BBL SA 080-0-01855-8 CA 080-3-00074-4 ศน.,1101020008,"bale[1101020008][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101020009,18,[1101020009]BBL SA 080-0-00279-2 CA 080-3-00008-2 ศช.,1101020009,"bale[1101020009][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101020010,19,[1101020010]BBL SA 080-0-00280-0 CA 080-3-00009-0 รายได้-ศช.,1101020010,"bale[1101020010][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101020011,20,[1101020011]BBL SA 080-0-00084-6 CA 080-3-00003-3 ศว.,1101020011,"bale[1101020011][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101020012,21,[1101020012]BBL SA 080-0-00178-6 รายได้-MTEC,1101020012,"bale[1101020012][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101020013,22,[1101020013]BBL SA 080-0-04444-8 CA 080-3-00118-9 ศอ.,1101020013,"bale[1101020013][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101020014,23,[1101020014]BBL SA 759-0-26380-7 ศช. ห้องปฏิบัติการสรีรวิทยาสัตว์,1101020014,"bale[1101020014][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101020015,24,[1101020015]SCB SA 324-2-56262-0 CA 324-3-03140-2 ซอฟต์แวร์#2,1101020015,"bale[1101020015][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101020016,25,[1101020016]SCB SA 667-2-15866-7 CA 667-3-00344-1 สวทช. ภาคเหนือ,1101020016,"bale[1101020016][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101020017,26,[1101020017]SCB SA 541-2-30920-2 CA 541-3-00951-2 ศวพก.,1101020017,"bale[1101020017][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101020018,27,[1101020018]TMB SA 069-2-19922-7 หน่วยฯ แป้ง (รายได้),1101020018,"bale[1101020018][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101020019,28,[1101020019]BAY SA 329-1-34850-3 CA 329-0-01347-6 ซอฟต์แวร์#2,1101020019,"bale[1101020019][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101020020,29,[1101020020]BBL SA 080-0-07531-9 CA 080-3-00162-7 กฟผ.-สวทช.,1101020020,"bale[1101020020][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101020021,30,[1101020021]BBL CA101-3-15558-3สนง.คณะกรรมการพัฒนาวิทยาศาสตร์ฯ,1101020021,"bale[1101020021][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101020022,31,[1101020022]KTB CA 475-6-00353-2 โครงการเงินกู้เพื่อพัฒนาระบบ,1101020022,"bale[1101020022][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101020023,32,[1101020023]BBL SA 080-0-12726-8 CA 080-3-00274-0  CTEC,1101020023,"bale[1101020023][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101020024,33,[1101020024]BBL SA 080-0-04983-5 CA 080-3-00121-3  DECC,1101020024,"bale[1101020024][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101020025,34,[1101020025]BBL SA 080-0-13324-1 เงินบริจาคกองทุนพัฒนาวิทยาศาสตร์,1101020025,"bale[1101020025][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101029990,35,[1101029990]เงินฝากธนาคาร-ออมทรัพย์ Interface,1101029990,"bale[1101029990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101030000,36,[1101030000]เงินฝากธนาคาร-ประจำ 3 เดือน,1101030000,"bale[1101030000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101030001,37,[1101030001]GSB SA 3-001798250-9 [3 เดือน] สวทช.,1101030001,"bale[1101030001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101030002,38,[1101030002]BBL FA 080-2-01168-4 [14 วัน] สวทช.,1101030002,"bale[1101030002][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101030003,39,[1101030003]TNC FA 482-1-10953-6 [1 เดือน] สวทช.,1101030003,"bale[1101030003][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101030004,40,[1101030004]BAY FA 669-2-01017-8 [2 เดือน] สวทช.,1101030004,"bale[1101030004][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101030005,41,[1101030005]SCB FA 464-018272-9 สวทช.,1101030005,"bale[1101030005][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101039990,42,[1101039990]เงินฝากธนาคาร-ประจำ Interface,1101039990,"bale[1101039990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101040000,43,[1101040000]เงินฝากธนาคารที่มีวัตถุประสงค์เฉพาะ,1101040000,"bale[1101040000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050000,44,[1101050000]เงินฝากธนาคารที่มีวัตถุประสงค์เฉพาะ-สกสว.,1101050000,"bale[1101050000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050001,45,[1101050001]BBL SA 080-0-10037-2 CA 080-3-00215-3 ทุนวิจัย สกว.-สวทช.,1101050001,"bale[1101050001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050002,46,[1101050002]BBL SA 080-0-11452-2 CA 080-3-00251-8 TRG58-กรกช,1101050002,"bale[1101050002][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050003,47,[1101050003]BBL SA 080-0-11551-1 CA 080-3-00257-5 RSA58-ชัยรัตน์,1101050003,"bale[1101050003][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050004,48,[1101050004]BBL SA 080-0-11555-2 CA 080-3-00259-1 BRG58-ปิติ,1101050004,"bale[1101050004][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050005,49,[1101050005]BBL SA 080-0-11556-0 CA 080-3-00260-9 RSA58-ศิษเฎศ,1101050005,"bale[1101050005][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050006,50,[1101050006]BBL SA 080-0-11576-8 CA 080-3-00262-5 RSA58-เปรมฤทัย,1101050006,"bale[1101050006][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050007,51,[1101050007]BBL SA 080-0-11755-8 CA 080-3-00272-4 TN-มาซาฮิโกะ,1101050007,"bale[1101050007][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050008,52,[1101050008]BBL SA 080-0-11894-5 CA 080-3-00276-5 RDG5850103-พิมพา,1101050008,"bale[1101050008][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050009,53,[1101050009]KTB SA 475-3-20610-6 CA 475-6-00500-4 ทุนวิจัย สกว,1101050009,"bale[1101050009][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050010,54,[1101050010]BBL SA 080-0-13037-9 CA 080-3-00336-7 เศรษฐลัทธ์,1101050010,"bale[1101050010][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050011,55,[1101050011]BBL SA 080-0-12002-4 CA 080-3-00286-4 TN-คทาวุธ,1101050011,"bale[1101050011][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050012,56,[1101050012]BBL SA 080-0-12003-2 CA 080-3-00287-2 TN-สินีนาฏ,1101050012,"bale[1101050012][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050013,57,[1101050013]BBL SA 080-0-12004-0 CA 080-3-00288-0 TN-นพดล,1101050013,"bale[1101050013][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050014,58,[1101050014]BBL SA 080-0-12365-5 CA 080-3-00297-1 TN-วัชริน ม.,1101050014,"bale[1101050014][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050015,59,[1101050015]BBL SA 080-0-12377-0 CA 080-3-00301-1 TN-อัยดา อ.,1101050015,"bale[1101050015][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050016,60,[1101050016]BBL SA 080-0-12374-7 CA 080-3-00298-9 TN-จีราพร ล.,1101050016,"bale[1101050016][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050017,61,[1101050017]BBL SA 080-0-12375-4 CA 080-3-00299-7 TN-สัญชัย ค.,1101050017,"bale[1101050017][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050018,62,[1101050018]BBL SA 080-0-12376-2 CA 080-3-00300-3 TN-สุวัสสา บ,1101050018,"bale[1101050018][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050019,63,[1101050019]BBL SA 080-0-12402-6 CA 080-3-00306-0 TN-ธริดาพร บ,1101050019,"bale[1101050019][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050020,64,[1101050020]BBL SA 080-0-12405-9 CA 080-3-00309-4 TN-สุธา ส.,1101050020,"bale[1101050020][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050021,65,[1101050021]BBL SA 080-0-12403-4 CA 080-3-00307-8 TN-ชลรัชต์ บ,1101050021,"bale[1101050021][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050022,66,[1101050022]BBL SA 080-0-12404-2 CA 080-3-00308-6 TN-ศันสนีย น,1101050022,"bale[1101050022][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050023,67,[1101050023]BBL SA 080-0-12388-7 CA 080-3-003037 TN-ขจรศักดิ์,1101050023,"bale[1101050023][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050024,68,[1101050024]BBL SA 080-0-12428-1 CA 080-3-00311-0 TN-กัลยาณ์ ศ.,1101050024,"bale[1101050024][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050025,69,[1101050025]BBL SA 080-0-12508-0 CA 080-3-00312-8 TN-ณัฐกา ส.,1101050025,"bale[1101050025][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050026,70,[1101050026]BBL SA 080-0-12509-8 CA 080-3-00313-6 TN-ชญาภา น.,1101050026,"bale[1101050026][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050027,71,[1101050027]BBL SA 080-0-12511-4 CA 080-3-00315-1 TN-อนุชา ว.,1101050027,"bale[1101050027][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050028,72,[1101050028]BBL SA 080-0-12642-7 CA 080-3-00319-3 TN-วีระวัฒน์,1101050028,"bale[1101050028][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050029,73,[1101050029]BBL SA 080-0-12643-5 CA 080-3-00320-1 TN-จักรพล,1101050029,"bale[1101050029][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050030,74,[1101050030]BBL SA 080-0-12677-3 CA 080-3-00321-9 TN-ชัยยันต์,1101050030,"bale[1101050030][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050031,75,[1101050031]BBL SA 080-0-12683-1 CA 080-3-00322-7 TN-พรพรรณ,1101050031,"bale[1101050031][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050032,76,[1101050032]BBL SA 080-0-12693-0 CA 080-3-00324-3 TN-ไพศาล,1101050032,"bale[1101050032][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050033,77,[1101050033]BBL SA 080-0-12695-5 CA 080-3-00325-0 TN- ยศวัต,1101050033,"bale[1101050033][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050034,78,[1101050034]BBL SA 080-0-11959-6 CA 080-3-00282-3 TN-สิรินาถ,1101050034,"bale[1101050034][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050035,79,[1101050035]KTB SA 475-3-09516-9 CA 475-6-00419-9 TN-อุรชา ร.,1101050035,"bale[1101050035][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050036,80,[1101050036]KTB SA 475-3-14302-3 CA 475-6-00462-8 TN-เทพชัย,1101050036,"bale[1101050036][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050037,81,[1101050037]KTB SA 475-3-19784-0 CA 475-6-00485-7 TN-ธงชัย ก.,1101050037,"bale[1101050037][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050038,82,[1101050038]BBL SA 080-0-11961-2 CA 080-3-00284-9 TN-ปัทมา,1101050038,"bale[1101050038][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050039,83,[1101050039]BBL SA 080-0-13120-3 CA 080-3-00341-7 TN-กิตติพงษ์,1101050039,"bale[1101050039][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050040,84,[1101050040]BBL SA 080-0-13122-9 CA 080-3-00343-3 TN-ธิติกร,1101050040,"bale[1101050040][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050041,85,[1101050041]BBL SA 080-0-13149-2 CA 080-3-00346-6 TN-อัญชลี,1101050041,"bale[1101050041][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050042,86,[1101050042]BBL SA 080-0-12692-2 CA 080-3-00323-5 TN-นิทัศน์ (DECC),1101050042,"bale[1101050042][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050043,87,[1101050043]BBL SA 080-0-13258-1 CA 080-3-00347-4 PT-ปัทมา,1101050043,"bale[1101050043][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050053,88,[1101050053]BBL SA 080-0-13413-2 CA 080-3-00359-9 TN-ณรงค์ พ.50026,1101050053,"bale[1101050053][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050054,89,[1101050054]BBL SA 080-0-13426-4 CA 080-3-00360-7 TN-ศราวุธ ล.50032,1101050054,"bale[1101050054][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050055,90,[1101050055]BBL SA 080-0-13455-3 CA 080-3-00361-5 TN-ปัทมา พ.20019,1101050055,"bale[1101050055][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050056,91,[1101050056]BBL SA 080-0-13482-7 CA 080-3-00362-3 TN-ศราวุธ ล.50039,1101050056,"bale[1101050056][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050057,92,[1101050057]BBL SA 080-013541-0 CA 080-3-00363-1 โรคติดเชื้อในสัตว์,1101050057,"bale[1101050057][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050044,93,[1101050044]BBL SA 080-0-13301-9 CA 080-3-00350-8 TN-วรรณพ.ว.50009,1101050044,"bale[1101050044][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050045,94,[1101050045]BBL SA 080-0-13298-7 CA 080-3-00348-2 TN-วรรณพ.ว.50006,1101050045,"bale[1101050045][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050046,95,[1101050046]BBL SA 080-0-13299-5 CA 080-3-00349-0 TN-วรรณพ.ว.50008,1101050046,"bale[1101050046][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050047,96,[1101050047]BBL SA 080-0-13302-7 CA 080-3-00351-6 TN-เกื้อกูล.ป.50002,1101050047,"bale[1101050047][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050048,97,[1101050048]BBL SA 080-0-13311-8 CA 080-3-00355-7 TN-วรรณพ.ว.50003,1101050048,"bale[1101050048][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050049,98,[1101050049]BBL SA 080-0-13308-4 CA 080-3-00352-4 TN-วรรณพ.ว.50004,1101050049,"bale[1101050049][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050050,99,[1101050050]BBL SA 080-0-13309-2 CA 080-3-00353-2 TN-วรรณพ.ว.50005,1101050050,"bale[1101050050][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050051,100,[1101050051]BBL SA 080-0-13310-0 CA 080-3-00354-0 'TN-วรรณพ.ว.50007,1101050051,"bale[1101050051][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101050052,101,[1101050052]BBL SA 080-0-13326-6 CA 080-3-00357-3 TN-วรรณพ.ว.50010,1101050052,"bale[1101050052][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101060000,102,[1101060000]เงินฝากธนาคารที่มีวัตถุประสงค์เฉพาะ-สวก.,1101060000,"bale[1101060000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101060001,103,[1101060001]KTB SA 475-0-88623-8 CA 475-6-00303-6 ผลิตเม็ดพันธุ์,1101060001,"bale[1101060001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101060003,104,[1101060003]BBL SA 080-0-12390-3 CA 080-3-00305-2 อาหารกุ้ง,1101060003,"bale[1101060003][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101060004,105,[1101060004]BBL SA 080-0-12389-5 CA 080-3-00304-5ต้านการอักเสบ,1101060004,"bale[1101060004][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101060005,106,[1101060005]BBL SA 080-0-12406-7 CA 080-3-00310-2 ข้าวทนหนาว,1101060005,"bale[1101060005][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101060006,107,[1101060006]BBL SA 080-0-12512-2 CA 080-3-00316-9 สิ่งทอไล่ยุง,1101060006,"bale[1101060006][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101060007,108,[1101060007]BBL SA 080-0-12510-6 CA 080-3-00314-4 จำแนกสปีชีส์,1101060007,"bale[1101060007][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101060008,109,[1101060008]KTB SA 475-3-08198-2 CA 475-6-00414-8 สีผิวผลปาล์ม,1101060008,"bale[1101060008][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101060009,110,[1101060009]KTB SA 475-3-10171-1 CA 475-6-00432-6 เมทาโบไลท์,1101060009,"bale[1101060009][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101060010,111,[1101060010]KTB SA 475-3-10170-3 CA 475-6-00431-8 โปรตีโอมิกส์,1101060010,"bale[1101060010][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101060011,112,[1101060011]KTB SA 475-3-10410-9 CA 475-6-00437-7 ตรวจมะละกอ,1101060011,"bale[1101060011][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101060014,113,[1101060014]KTB SA 475-3-10748-5 CA 475-6-00450-4 เนื้อเยื่อ,1101060014,"bale[1101060014][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101060015,114,[1101060015]KTB SA 475-3-19732-8 CA 475-6-00483-0 ข้าวลูกผสม#3,1101060015,"bale[1101060015][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101060016,115,[1101060016]KTB SA 475-3-19733-6 CA 475-6-00484-9 พิมพ์ DNA#3,1101060016,"bale[1101060016][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101060017,116,[1101060017]KTB SA 475-3-20777-3 CA 475-6-00502-0 การประยุกต์,1101060017,"bale[1101060017][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101060018,117,[1101060018]KTB SA 475-3-21238-6 CA 475-6-00519-5 การประเมิน,1101060018,"bale[1101060018][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101060019,118,[1101060019]KTB SA 475-3-21824-4 CA 475-6-00549-7 มะพร้าวไทย,1101060019,"bale[1101060019][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101060020,119,[1101060020]KTB SA 475-3-21840-6 CA 475-6-00550-0 พันธุกรรมข้าว,1101060020,"bale[1101060020][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101060021,120,[1101060021]KTB SA 475-3-21839-2 CA 475-6-00551-9 ข้าวเรณู,1101060021,"bale[1101060021][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101060022,121,[1101060022]KTB SA 475-3-21867-8 CA 475-6-00552-7 แม่เป็นหมัน,1101060022,"bale[1101060022][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101060023,122,[1101060023]KTB SA 475-3-21894-5 CA 475-6-00553-5 การปลูกอ้อย,1101060023,"bale[1101060023][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101060024,123,[1101060024]KTB SA 475-3-30630-5 CA 475-6-00561-6  นิวคลีโอไทด์,1101060024,"bale[1101060024][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101060025,124,[1101060025]KTB SA 475-3-31608-4 CA 475-6-00572-1  ปลากัดไทย,1101060025,"bale[1101060025][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101060026,125,[1101060026]KTB SA 475-3-31624-6 CA 475-6-00574-8  โรคในปลานิล,1101060026,"bale[1101060026][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101060027,126,[1101060027]KTB SA 475-3-31625-4 CA 475-6-00575-6  เมล็ดพริก,1101060027,"bale[1101060027][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101060028,127,[1101060028]BBL SA 080-0-11748-3 CA 080-3-00271-6 โรงเรือนกล้วยไม้ (DECC),1101060028,"bale[1101060028][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101060029,128,[1101060029]KTB SA 475-3-31713-7 CA 475-6-00578-0 ผลิตภัณฑ์สุกร,1101060029,"bale[1101060029][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101060030,129,[1101060030]KTB SA 475-3-31956-3 CA 475-6-00580-2 โรคใบขาวของอ้อย,1101060030,"bale[1101060030][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101060031,130,[1101060031]KTB SA 475-3-32011-1 CA 475-6-00583-7 กุ้งขาวแวนนาไม,1101060031,"bale[1101060031][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101060032,131,[1101060032]KTB SA 475-3-32032-4 CA 475-6-00584-5 สไปรูลินา,1101060032,"bale[1101060032][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101060033,132,[1101060033]KTB SA 475-3-32078-2 CA 475-6-00585-3 อาหารกุ้ง (ปีที่ ๒),1101060033,"bale[1101060033][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101060034,133,[1101060034]KTB SA 475-3-32218-1 CA 475-6-00595-0 เชื้อ EHP ในกุ้งขาว,1101060034,"bale[1101060034][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101060035,134,[1101060035]KTB SA 475-3-32271-8 CA 475-6-00596-9 เรณูเป็นหมัน,1101060035,"bale[1101060035][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101060036,135,[1101060036]KTB SA 475-3-32603-9 CA 475-6-00608-6 ขยายพันธุ์ปาล์ม (ปีที่ 3),1101060036,"bale[1101060036][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101060037,136,[1101060037]KTB SA 475-3-39835-8 CA 475-6-00612-4 ความสุกของปาล์ม (ปีที่ 2),1101060037,"bale[1101060037][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101060038,137,[1101060038]KTB SA 475-3-41696-8 CA 475-6-00622-1 พัฒนาฐานข้อมูล,1101060038,"bale[1101060038][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101070000,138,[1101070000]เงินฝากธนาคารที่มีวัตถุประสงค์เฉพาะ-สสส.,1101070000,"bale[1101070000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101070001,139,[1101070001]BBL SA 080-0-12334-1 CA 080-3-00294-8 ผู้สูงอายุ,1101070001,"bale[1101070001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101080000,140,[1101080000]เงินฝากธนาคารที่มีวัตถุประสงค์เฉพาะ-วช.,1101080000,"bale[1101080000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101080002,141,[1101080002]KTB SA 475-0-64783-7 CA 475-6-00181-5 ศช. (การพัฒนาคุณภาพของผลมะละกอฯ),1101080002,"bale[1101080002][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101080003,142,[1101080003]KTB SA 475-0-76367-5 CA 475-6-00215-3 สำปะหลัง วช.56,1101080003,"bale[1101080003][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101080004,143,[1101080004]KTB SA 475-0-76369-1 CA 475-6-00216-1 ระบบราง วช.56,1101080004,"bale[1101080004][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101080005,144,[1101080005]KTB SA 475-0-78591-1 CA 475-6-00253-6 สำปะหลัง วช.57,1101080005,"bale[1101080005][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101080006,145,[1101080006]KTB SA 475-0-79325-6 CA 475-6-00258-7 ระบบราง วช.57,1101080006,"bale[1101080006][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101080007,146,[1101080007]KTB SA 475-0-88852-4 CA 475-6-00317-6 ลดมลพิษ,1101080007,"bale[1101080007][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101080008,147,[1101080008]KTB SA 475-0-88875-3 CA 475-6-00318-4 สำปะหลัง วช.58,1101080008,"bale[1101080008][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101080009,148,[1101080009]KTB SA 475-0-88878-8 CA 475-6-00319-2 ระบบราง วช.58,1101080009,"bale[1101080009][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101080010,149,[1101080010]KTB SA 475-0-89246-7 CA 475-6-00327-3 ชนิดดูดซึม,1101080010,"bale[1101080010][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101080011,150,[1101080011]KTB SA 475-0-89362-5 CA 475-6-00333-8 กุ้งตายด่วน,1101080011,"bale[1101080011][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101080012,151,[1101080012]KTB SA 475-0-89395-1 CA 475-6-00336-2 ตั๊กแตน,1101080012,"bale[1101080012][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101080013,152,[1101080013]KTB SA 475-0-97573-7 CA 475-6-00349-4 วัสดุนาโน,1101080013,"bale[1101080013][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101080014,153,[1101080014]KTB SA 475-0-99621-1 CA 475-6-00378-8 ระบบราง วช.59,1101080014,"bale[1101080014][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101080015,154,[1101080015]KTB SA 475-0-99620-3 CA 475-6-00376-1 สำปะหลัง วช.59,1101080015,"bale[1101080015][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101080016,155,[1101080016]KTB SA 475-3-00316-7 CA475-6-00402-4เคมีไฟฟ้าพกพา2,1101080016,"bale[1101080016][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101080017,156,[1101080017]KTB SA 475-3-00474-0 CA 475-6-00405-9 ประยุกต์ใช้,1101080017,"bale[1101080017][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101080018,157,[1101080018]BBL SA 080-0-09735-4 CA 080-3-00205-4 สวทช.-แผ่นกรองอากาศนาโน,1101080018,"bale[1101080018][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101080019,158,[1101080019]KTB SA 475-3-09637-8 CA 475-6-00420-2 จมูกอัจฉริยะ,1101080019,"bale[1101080019][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101080020,159,[1101080020]KTB SA 475-3-09671-8 CA 475-6-00422-9 เดนตีสแกน,1101080020,"bale[1101080020][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101080021,160,[1101080021]KTB SA 475-3-10409-5 CA 475-6-00436-9 พิพิธภัณฑ์,1101080021,"bale[1101080021][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101080022,161,[1101080022]KTB SA 475-3-10572-5 CA 475-6-00448-2สำปะหลัง วช60,1101080022,"bale[1101080022][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101080023,162,[1101080023]KTB SA 475-3-10571-7 CA 475-6-00447-4 ระบบราง วช60,1101080023,"bale[1101080023][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101080024,163,[1101080024]KTB SA 475-3-14306-6 CA 475-6-00464-4 ขนส่ง วช.59,1101080024,"bale[1101080024][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101080026,164,[1101080026]KTB SA 475-3-19382-9 CA 475-6-00481-4 ผลิตอนุภาคนา,1101080026,"bale[1101080026][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101080027,165,[1101080027]KTB SA 475-3-21562-8 CA 475-6-00537-3 การพัฒนา,1101080027,"bale[1101080027][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101090000,166,[1101090000]เงินฝากธนาคารที่มีวัตถุประสงค์เฉพาะ-แหล่งอื่น ๆ,1101090000,"bale[1101090000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101090001,167,[1101090001]BBL SA 080-0-07530-1 CA 080-3-00163-5 Tokyo tech,1101090001,"bale[1101090001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101090002,168,[1101090002]BBL SA 080-0-09540-8 CA 080-3-00198-1 มอเตอร์และระบบขับเคลื่อน,1101090002,"bale[1101090002][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101090003,169,[1101090003]BBL SA 080-0-12356-4 CA 080-3-00296-3 DAM SAFETY,1101090003,"bale[1101090003][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101090004,170,[1101090004]BBL SA 080-0-12383-8 CA 080-3-00302-9 NETPIE IOT,1101090004,"bale[1101090004][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101090005,171,[1101090005]BBL SA 080-0-12513-0 CA 080-3-00317-7 แบบจำลอง,1101090005,"bale[1101090005][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101090006,172,[1101090006]BBL SA 080-0-12839-9 CA 080-3-00327-6 เงินนอก ศอ.,1101090006,"bale[1101090006][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101090008,173,[1101090008]BBL SA 080-0-12908-2 CA 080-3-00329-2 สหสถาบัน,1101090008,"bale[1101090008][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101090009,174,[1101090009]BBL SA 080-0-12989-2 CA 080-3-00330-0 ค้นหายา,1101090009,"bale[1101090009][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101090010,175,[1101090010]BBL SA 080-0-12994-2 CA 080-3-00331-8 เก็บพลังงาน,1101090010,"bale[1101090010][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101090011,176,[1101090011]BBL SA 080-0-12999-1 CA 080-3-00332-6 SolarMove,1101090011,"bale[1101090011][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101090012,177,[1101090012]BBL SA 080-0-13000-7 CA 080-3-00333-4 Health,1101090012,"bale[1101090012][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101090013,178,[1101090013]BBL SA 080-0-13019-7 CA 080-3-00334-2 ผู้ประกอบการ,1101090013,"bale[1101090013][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101090015,179,[1101090015]BBL SA 080-0-13050-2 CA 080-3-00337-5 เพอรอฟสไกต์,1101090015,"bale[1101090015][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101090016,180,[1101090016]KTB SA 475-3-08320-9 CA 475-6-00417-2Energy-บริหาร,1101090016,"bale[1101090016][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101090017,181,[1101090017]KTB SA 475-3-08322-5 CA 475-6-00418-0Energyอุดหนุน,1101090017,"bale[1101090017][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101090018,182,[1101090018]KTB SA 475-3-09923-7 CA 475-6-00423-7 ไบโอดีเซล,1101090018,"bale[1101090018][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101090019,183,[1101090019]KTB SA 475-3-14305-8 CA 475-6-00463-6 กองทุนฯ,1101090019,"bale[1101090019][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101090020,184,[1101090020]KTB SA 475-3-20534-7 CA 475-6-00495-4 พัฒนาผงสี,1101090020,"bale[1101090020][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101090021,185,[1101090021]KTB SA 475-3-20533-9 CA 475-6-00494-6การใช้พลังงาน,1101090021,"bale[1101090021][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101090022,186,[1101090022]KTB SA 475-3-20876-1 CA 475-6-00509-8 เยื่อเลือก,1101090022,"bale[1101090022][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101090023,187,[1101090023]BBL SA 080-0-13061-9 CA 080-3-00339-1 พลังงานลม,1101090023,"bale[1101090023][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101090024,188,[1101090024]BBL SA 080-0-13064-3 CA 080-3-00340-9 อัตราค่าไฟฟ้า,1101090024,"bale[1101090024][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101090025,189,[1101090025]BBL SA 080-0-13121-1 CA 080-3-00342-5 One year project,1101090025,"bale[1101090025][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101090026,190,[1101090026]BBL SA 080-0-13126-0 CA 080-3-00344-1 มิวเทอร์ม-เฟสเซอซ์,1101090026,"bale[1101090026][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101090027,191,[1101090027]BBL SA 080-0-13136-9 CA 080-3-00345-8 รถโดยสารประจำทาง,1101090027,"bale[1101090027][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101090028,192,[1101090028]KTB SA 475-3-31857-5 CA 475-6-00579-9 เศรษฐกิจดิจิทัล,1101090028,"bale[1101090028][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101090029,193,[1101090029]KTB SA 475-3-31978-4 CA 475-6-00581-0 เศรษฐกิจดิจิทัล (MP-61-0006),1101090029,"bale[1101090029][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101090030,194,[1101090030]KTB SA 475-3-32354-4 CA 475-6-00599-3 สวทช.เงินนอกงบประมาณ,1101090030,"bale[1101090030][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101090031,195,[1101090031]BBL SA 080-0-13325-8 CA 080-3-00356-5 ทดสอบซอฟต์แวร์ ,1101090031,"bale[1101090031][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101090032,196,[1101090032]KTB SA 475-3-32462-1 CA 475-6-00600-0 เศรษฐกิจดิจิทัล (SP-62-0053),1101090032,"bale[1101090032][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101090033,197,[1101090033]KTB SA 475-3-32464-8 CA 475-6-00601-9 เศรษฐกิจดิจิทัล (SP-62-0054),1101090033,"bale[1101090033][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101090034,198,[1101090034]BBL SA 080-0-13350-6 CA 080-3-00358-1 อาหารฟังก์ชั่น,1101090034,"bale[1101090034][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101090035,199,[1101090035]KTB SA 475-3-42387-5 CA 475-6-00633-7 MalHivPOCTs,1101090035,"bale[1101090035][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101090036,200,[1101090036]KTB SA 475-3-42404-9 CA 475-6-00634-5 เซลล์ Vero และ MDCK,1101090036,"bale[1101090036][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101090037,201,[1101090037]KTB SA 475-3-42406-5 CA 475-6-00635-3 เพาะปลูกกัญชา,1101090037,"bale[1101090037][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1101099990,202,[1101099990]เงินฝากธนาคารที่มีวัตถุประสงค์เฉพาะ Interface,1101099990,"bale[1101099990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1102010000,203,[1102010000]ลูกหนี้การค้า,1102010000,"bale[1102010000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1102010001,204,[1102010001]ลูกหนี้การค้า - ในประเทศ หน่วยงานภาครัฐ,1102010001,"bale[1102010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1102010002,205,[1102010002]ลูกหนี้การค้า - ในประเทศ หน่วยงานเอกชน,1102010002,"bale[1102010002][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1102010003,206,[1102010003]ลูกหนี้การค้า - ต่างประเทศ,1102010003,"bale[1102010003][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1102010004,207,[1102010004]ลูกหนี้อยู่ระหว่างดำเนินคดี,1102010004,"bale[1102010004][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1102010005,208,[1102010005]ลูกหนี้ผ่อนชำระ,1102010005,"bale[1102010005][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1102010006,209,[1102010006]ลูกหนี้เงินให้กู้ระยะยาว - CD,1102010006,"bale[1102010006][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1102019990,210,[1102019990]ลูกหนี้การค้า - ในประเทศ หน่วยงานภาครัฐ Interface,1102019990,"bale[1102019990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1102019991,211,[1102019991]ลูกหนี้การค้า - ในประเทศ หน่วยงานเอกชน Interface,1102019991,"bale[1102019991][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1102019992,212,[1102019992]ลูกหนี้การค้า - ต่างประเทศ Interface,1102019992,"bale[1102019992][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1102019993,213,[1102019993]ลูกหนี้อยู่ระหว่างดำเนินคดี Interface,1102019993,"bale[1102019993][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1102019994,214,[1102019994]ลูกหนี้ผ่อนชำระ Interface,1102019994,"bale[1102019994][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1103010000,215,[1103010000]ค่าเผื่อหนี้สงสัยจะสูญ,1103010000,"bale[1103010000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1103010001,216,[1103010001]ค่าเผื่อหนี้สงสัยจะสูญ,1103010001,"bale[1103010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1103019990,217,[1103019990]ค่าเผื่อหนี้สงสัยจะสูญ Interface,1103019990,"bale[1103019990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1104010000,218,[1104010000]เงินยืมทดรองจ่ายให้พนักงาน,1104010000,"bale[1104010000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1104010001,219,[1104010001]เงินยืมทดรองจ่าย,1104010001,"bale[1104010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1104019990,220,[1104019990]เงินยืมทดรองจ่าย Interface,1104019990,"bale[1104019990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1105010000,221,[1105010000]วัสดุคงเหลือ,1105010000,"bale[1105010000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1105010001,222,[1105010001]วัสดุสำนักงาน,1105010001,"bale[1105010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1105010002,223,[1105010002]วัสดุโฆษณาและเผยแพร่,1105010002,"bale[1105010002][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1105010003,224,[1105010003]วัสดุงานบ้านและงานครัว,1105010003,"bale[1105010003][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1105010004,225,[1105010004]วัสดุหนังสือ วารสาร และตำรา,1105010004,"bale[1105010004][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1105010005,226,[1105010005]วัสดุวิทยาศาสตร์,1105010005,"bale[1105010005][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1105010006,227,[1105010006]วัสดุคอมพิวเตอร์,1105010006,"bale[1105010006][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1105010007,228,[1105010007]วัสดุไฟฟ้าและวิทยุ,1105010007,"bale[1105010007][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1105010008,229,[1105010008]วัสดุอุปกรณ์ทางการแพทย์,1105010008,"bale[1105010008][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1105010009,230,[1105010009]วัสดุกีฬา/ดนตรีนาฎศิลป์,1105010009,"bale[1105010009][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1105010010,231,[1105010010]วัสดุงานวิจัยต้นแบบ,1105010010,"bale[1105010010][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1105010011,232,[1105010011]พักโอนเข้าวัสดุคงเหลือจากการ Settlement I/O,1105010011,"bale[1105010011][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1105019990,233,[1105019990]วัสดุคงเหลือ-Interface,1105019990,"bale[1105019990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1106010000,234,[1106010000]ค่าใช้จ่ายล่วงหน้า,1106010000,"bale[1106010000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1106010001,235,[1106010001]ค่าเช่าจ่ายล่วงหน้า,1106010001,"bale[1106010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1106010002,236,[1106010002]ค่าประกันภัยจ่ายล่วงหน้า,1106010002,"bale[1106010002][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1106019991,237,[1106019991]ค่าประกันจ่ายล่วงหน้า Interface,1106019991,"bale[1106019991][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1106010003,238,[1106010003]ค่าสมาชิก หนังสือและวารสารจ่ายล่วงหน้า,1106010003,"bale[1106010003][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1106019992,239,[1106019992]ค่าสมาชิก/หนังสือและวารสารจ่ายล่วงหน้า Interface,1106019992,"bale[1106019992][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1106010004,240,[1106010004]ค่าลิขสิทธ์จ่ายล่วงหน้า,1106010004,"bale[1106010004][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1106019993,241,[1106019993]ค่าลิขสิทธ์จ่ายล่วงหน้า Interface,1106019993,"bale[1106019993][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1106010005,242,[1106010005]ค่า AUC จ่ายล่วงหน้า,1106010005,"bale[1106010005][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1106010006,243,[1106010006]ค่า AIT จ่ายล่วงหน้า,1106010006,"bale[1106010006][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1106019995,244,[1106019995]ค่า AIT จ่ายล่วงหน้า Interface,1106019995,"bale[1106019995][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1106019994,245,[1106019994]ค่า AUC จ่ายล่วงหน้า Interface,1106019994,"bale[1106019994][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1106010007,246,[1106010007]ค่าใช้จ่ายจ่ายล่วงหน้าอื่น,1106010007,"bale[1106010007][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1106019996,247,[1106019996]ค่าใช้จ่ายจ่ายล่วงหน้าอื่น Interface,1106019996,"bale[1106019996][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1106010008,248,[1106010008]เงินจ่ายล่วงหน้าอื่น,1106010008,"bale[1106010008][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1106019997,249,[1106019997]เงินจ่ายล่วงหน้าอื่น Interface,1106019997,"bale[1106019997][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1106019990,250,[1106019990]ค่าเช่าจ่ายล่วงหน้า Interface,1106019990,"bale[1106019990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1107010000,251,[1107010000]เงินอุดหนุนจากงบประมาณแผ่นดินค้างรับ,1107010000,"bale[1107010000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1107010001,252,[1107010001]เงินอุดหนุนจากงบประมาณแผ่นดินค้างรับ-อุดหนุนเฉพาะกิจ,1107010001,"bale[1107010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1107010090,253,[1107010090]เงินอุดหนุนจากงบประมาณแผ่นดินค้างรับ Interface,1107010090,"bale[1107010090][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1107010002,254,[1107010002]เงินอุดหนุนจากงบประมาณแผ่นดินค้างรับ-อุดหนุนทั่วไป,1107010002,"bale[1107010002][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1108010000,255,[1108010000]ดอกเบี้ยค้างรับ,1108010000,"bale[1108010000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1108010001,256,[1108010001]ดอกเบี้ยค้างรับ,1108010001,"bale[1108010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1108010090,257,[1108010090]ดอกเบี้ยค้างรับ Interface,1108010090,"bale[1108010090][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1109010000,258,[1109010000]ภาษีมูลค่าเพิ่ม,1109010000,"bale[1109010000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1109010001,259,[1109010001]ภาษีซื้อ,1109010001,"bale[1109010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1109010002,260,[1109010002]ภาษีมูลค่าเพิ่ม,1109010002,"bale[1109010002][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1109010003,261,[1109010003]พักภาษีซื้อ,1109010003,"bale[1109010003][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1109010090,262,[1109010090]พักภาษีซื้อ Interface,1109010090,"bale[1109010090][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1190000000,263,[1190000000]สินทรัพย์หมุนเวียนอื่น,1190000000,"bale[1190000000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1190010000,264,[1190010000]ลูกหนี้อื่น,1190010000,"bale[1190010000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1190010001,265,[1190010001]ลูกหนี้หน่วยบริการ,1190010001,"bale[1190010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1190019990,266,[1190019990]ลูกหนี้หน่วยบริการ Interface,1190019990,"bale[1190019990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1190010002,267,[1190010002]เงินรอรับรู้ - ส/ท,1190010002,"bale[1190010002][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1190019900,268,[1190019900]ลูกหนี้อื่น,1190019900,"bale[1190019900][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1190019991,269,[1190019991]ลูกหนี้อื่น ๆ Interface,1190019991,"bale[1190019991][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1190900000,270,[1190900000]สินทรัพย์หมุนเวียนอื่น,1190900000,"bale[1190900000][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1190909900,271,[1190909900]สินทรัพย์หมุนเวียนอื่น,1190909900,"bale[1190909900][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1200000000,272,[1200000000]สินทรัพย์ไม่หมุนเวียน,1200000000,"bale[1200000000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1201000000,273,[1201000000]เงินฝากธนาคารประจำ มากกว่า 3 เดือน,1201000000,"bale[1201000000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1201010000,274,[1201010000]เงินฝากธนาคาร-ประจำ มากกว่า 3-12 เดือน,1201010000,"bale[1201010000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1201010001,275,[1201010001]BBL FA 942-6-00007-2 สวทช.[12 เดือน],1201010001,"bale[1201010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1201010002,276,[1201010002]BBL FA 080-2-01142-9 [4 เดือน],1201010002,"bale[1201010002][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1201010003,277,[1201010003]BBL FA 080-2-01363-1 (10 เดือน),1201010003,"bale[1201010003][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1201010004,278,[1201010004]TNC FA 482-1-10949-7 (6 เดือน),1201010004,"bale[1201010004][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1201010005,279,[1201010005]เงินโอนระหว่างธนาคาร,1201010005,"bale[1201010005][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1201019990,280,[1201019990]เงินฝากธนาคาร-ประจำ มากกว่า 3-12 เดือน Interface,1201019990,"bale[1201019990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1201020000,281,[1201020000]เงินฝากธนาคาร-ประจำเกิน 1 ปี,1201020000,"bale[1201020000][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1201029990,282,[1201029990]เงินฝากธนาคาร-ประจำเกิน 1 ปี ธนาคารรัฐ Interface,1201029990,"bale[1201029990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1202000000,283,[1202000000]เงินให้กู้ระยะยาว,1202000000,"bale[1202000000][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1202019900,284,[1202019900]เงินให้กู้ระยะยาวอื่น,1202019900,"bale[1202019900][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1203000000,285,[1203000000]เงินลงทุนระยะยาว,1203000000,"bale[1203000000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1203010000,286,[1203010000]เงินลงทุนในบริษัท จำกัด สุทธิ,1203010000,"bale[1203010000][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1203010001,287,[1203010001]เงินลงทุนในบริษัทจำกัด,1203010001,"bale[1203010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1203010002,288,[1203010002]ปรับมูลค่าเงินลงทุนในบริษัทจำกัด,1203010002,"bale[1203010002][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1203010003,289,[1203010003]ค่าเผื่อการด้อยค่า-เงินลงทุนในบริษัทจำกัด,1203010003,"bale[1203010003][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1203900000,290,[1203900000]เงินลงทุนระยะยาวอื่น,1203900000,"bale[1203900000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1203900001,291,[1203900001]เงินลงทุนระยะยาว,1203900001,"bale[1203900001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1203900002,292,[1203900002]ปรับมูลค่าเงินลงทุนระยะยาว,1203900002,"bale[1203900002][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1203900003,293,[1203900003]ค่าเผื่อการด้อยค่า-เงินลงทุนระยะยาว,1203900003,"bale[1203900003][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1203909990,294,[1203909990]ค่าเผื่อการด้อยค่า-เงินลงทุนระยะยาว Interface,1203909990,"bale[1203909990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1203900004,295,[1203900004]เงินลงทุนเผื่อขาย,1203900004,"bale[1203900004][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1203909991,296,[1203909991]เงินลงทุนเผื่อขาย Interface,1203909991,"bale[1203909991][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1204000000,297,[1204000000]เงินร่วมลงทุน,1204000000,"bale[1204000000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1204010001,298,[1204010001]เงินลงทุนหน่วยบริการ,1204010001,"bale[1204010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1204019990,299,[1204019990]เงินลงทุนหน่วยบริการ Interface,1204019990,"bale[1204019990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1205000000,300,[1205000000]เงินค้ำประกันจ่าย,1205000000,"bale[1205000000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1205010001,301,[1205010001]เงินค้ำประกันสัญญา,1205010001,"bale[1205010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1205010002,302,[1205010002]เงินค้ำประกันผลงาน,1205010002,"bale[1205010002][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1205019990,303,[1205019990]เงินค้ำประกันสัญญา Interface,1205019990,"bale[1205019990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1205019991,304,[1205019991]เงินค้ำประกันผลงาน Interface,1205019991,"bale[1205019991][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1206000000,305,[1206000000]เงินมัดจำ,1206000000,"bale[1206000000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1206010001,306,[1206010001]เงินมัดจำ-ค่าเช่าอาคาร ค่าบริการ,1206010001,"bale[1206010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1206010002,307,[1206010002]เงินมัดจำ-ค่าโทรศัพท์,1206010002,"bale[1206010002][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1206010003,308,[1206010003]เงินมัดจำ-อื่น,1206010003,"bale[1206010003][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1206019990,309,[1206019990]เงินมัดจำ-ค่าเช่าอาคาร/ค่าบริการ Interface,1206019990,"bale[1206019990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1206019991,310,[1206019991]เงินมัดจำ-ค่าโทรศัพท์ Interface,1206019991,"bale[1206019991][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1206019992,311,[1206019992]เงินมัดจำ-อื่น Interface,1206019992,"bale[1206019992][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1207000000,312,[1207000000]อสังหาริมทรัยพ์เพื่อการลงทุน,1207000000,"bale[1207000000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1207010000,313,[1207010000]อาคาร/ส่วนปรับปรุงอาคารเพื่อการลงทุน,1207010000,"bale[1207010000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1207010001,314,[1207010001]อาคารเพื่อการลงทุน,1207010001,"bale[1207010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1207010002,315,[1207010002]ส่วนปรับปรุงอาคารเพื่อการลงทุน,1207010002,"bale[1207010002][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1207019990,316,[1207019990]อาคารเพื่อการลงทุน Interface,1207019990,"bale[1207019990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1207019991,317,[1207019991]ส่วนปรับปรุงอาคารเพื่อการลงทุน Interface,1207019991,"bale[1207019991][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1208000000,318,[1208000000]ที่ดิน อาคารและครุภัณฑ์,1208000000,"bale[1208000000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1208010000,319,[1208010000]ที่ดิน/ส่วนปรับปรุงที่ดิน,1208010000,"bale[1208010000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1208010001,320,[1208010001]ที่ดิน,1208010001,"bale[1208010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1208010002,321,[1208010002]ส่วนปรับปรุงที่ดิน,1208010002,"bale[1208010002][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1208019990,322,[1208019990]ที่ดิน Interface,1208019990,"bale[1208019990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1208019991,323,[1208019991]ส่วนปรับปรุงที่ดิน Interface,1208019991,"bale[1208019991][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1208020000,324,[1208020000]อาคาร/ส่วนปรับปรุอาคาร,1208020000,"bale[1208020000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1208020001,325,[1208020001]อาคาร,1208020001,"bale[1208020001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1208020002,326,[1208020002]อาคารชั่วคราว,1208020002,"bale[1208020002][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1208020003,327,[1208020003]สิ่งปลูกสร้าง,1208020003,"bale[1208020003][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1208020004,328,[1208020004]ส่วนปรับปรุงอาคาร,1208020004,"bale[1208020004][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1208029990,329,[1208029990]อาคาร Interface,1208029990,"bale[1208029990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1208029991,330,[1208029991]อาคารชั่วคราว Interface,1208029991,"bale[1208029991][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1208029992,331,[1208029992]สิ่งปลูกสร้าง Interface,1208029992,"bale[1208029992][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1208029993,332,[1208029993]ส่วนปรับปรุงอาคาร Interface,1208029993,"bale[1208029993][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1208030000,333,[1208030000]ครุภัณฑ์,1208030000,"bale[1208030000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1208030001,334,[1208030001]ครุภัณฑ์และอุปกรณ์สำนักงาน,1208030001,"bale[1208030001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1208030002,335,[1208030002]ครุภัณฑ์และอุปกรณ์วิทยาศาสตร์,1208030002,"bale[1208030002][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1208030003,336,[1208030003]ครุภัณฑ์และอุปกรณ์โฆษณาและเผยแพร่,1208030003,"bale[1208030003][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1208030004,337,[1208030004]ครุภัณฑ์และอุปกรณ์ไฟฟ้าและวิทยุ,1208030004,"bale[1208030004][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1208030005,338,[1208030005]ครุภัณฑ์และอุปกรณ์คอมพิวเตอร์,1208030005,"bale[1208030005][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1208030006,339,[1208030006]ครุภัณฑ์และอุปกรณ์งานบ้านงานครัว,1208030006,"bale[1208030006][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1208030007,340,[1208030007]ครุภัณฑ์และอุปกรณ์การแพทย์,1208030007,"bale[1208030007][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1208030008,341,[1208030008]ครุภัณฑ์และอุปกรณ์การเกษตร,1208030008,"bale[1208030008][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1208030009,342,[1208030009]ครุภัณฑ์และอุปกรณ์กีฬา/ดนตรีนาฏศิลป์,1208030009,"bale[1208030009][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1208030010,343,[1208030010]ครุภัณฑ์และอุปกรณ์ก่อสร้าง,1208030010,"bale[1208030010][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1208039990,344,[1208039990]ครุภัณฑ์และอุปกรณ์สำนักงาน Interface,1208039990,"bale[1208039990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1208039991,345,[1208039991]ครุภัณฑ์และอุปกรณ์วิทยาศาสตร์ Interface,1208039991,"bale[1208039991][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1208039992,346,[1208039992]ครุภัณฑ์และอุปกรณ์โฆษณาและเผยแพร่ Interface,1208039992,"bale[1208039992][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1208039993,347,[1208039993]ครุภัณฑ์และอุปกรณ์ไฟฟ้าและวิทยุ Interface,1208039993,"bale[1208039993][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1208039994,348,[1208039994]ครุภัณฑ์และอุปกรณ์คอมพิวเตอร์ Interface,1208039994,"bale[1208039994][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1208039995,349,[1208039995]ครุภัณฑ์และอุปกรณ์งานบ้านงานครัว Interface,1208039995,"bale[1208039995][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1208039996,350,[1208039996]ครุภัณฑ์และอุปกรณ์การแพทย์ Interface,1208039996,"bale[1208039996][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1208039997,351,[1208039997]ครุภัณฑ์และอุปกรณ์การเกษตร Interface,1208039997,"bale[1208039997][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1208039998,352,[1208039998]ครุภัณฑ์และอุปกรณ์กีฬา/ดนตรีนาฏศิลป์ Interface,1208039998,"bale[1208039998][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1208039999,353,[1208039999]ครุภัณฑ์และอุปกรณ์ก่อสร้าง Interface,1208039999,"bale[1208039999][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1209000000,354,[1209000000]ยานพาหนะ,1209000000,"bale[1209000000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1209010000,355,[1209010000]ยานพาหนะ,1209010000,"bale[1209010000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1209010001,356,[1209010001]ยานพาหนะ,1209010001,"bale[1209010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1209019990,357,[1209019990]ยานพาหนะ-Interface,1209019990,"bale[1209019990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1210000000,358,[1210000000]สินทรัพย์ไม่มีตัวตน,1210000000,"bale[1210000000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1210010000,359,[1210010000]สินทรัพย์ไม่มีตัวตน,1210010000,"bale[1210010000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1210010001,360,[1210010001]สินทรัพย์ไม่มีตัวตน,1210010001,"bale[1210010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1210019990,361,[1210019990]สินทรัพย์ไม่มีตัวตน Interface,1210019990,"bale[1210019990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1211000000,362,[1211000000]สินทรัพย์ตามสัญญาเช่าการเงิน,1211000000,"bale[1211000000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1211010000,363,[1211010000]สินทรัพย์ตามสัญญาเช่าการเงิน,1211010000,"bale[1211010000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1211010001,364,[1211010001]สินทรัพย์ตามสัญญาเช่าการเงิน,1211010001,"bale[1211010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1211019990,365,[1211019990]สินทรัพย์ตามสัญญาเช่าการเงิน Interface,1211019990,"bale[1211019990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212000000,366,[1212000000]ค่าเสื่อมราคาสะสม,1212000000,"bale[1212000000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212010000,367,[1212010000]ค่าเสื่อมสะสม-อาคาร/ส่วนปรับปรุงอาคารเพื่อการลงทุน,1212010000,"bale[1212010000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212010001,368,[1212010001]ค่าเสื่อมสะสม-อาคารเพื่อการลงทุน,1212010001,"bale[1212010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212010002,369,[1212010002]ค่าเสื่อมสะสม-ส่วนปรับปรุงอาคารเพื่อการลงทุน,1212010002,"bale[1212010002][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212019990,370,[1212019990]ค่าเสื่อมสะสม-อาคารเพื่อการลงทุน Interface,1212019990,"bale[1212019990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212019991,371,[1212019991]ค่าเสื่อมสะสม-ส่วนปรับปรุงอาคารเพื่อการลงทุน Interface,1212019991,"bale[1212019991][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212020000,372,[1212020000]ค่าเสื่อมสะสม-ส่วนปรับปรุงที่ดิน,1212020000,"bale[1212020000][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212020001,373,[1212020001]ค่าเสื่อมสะสม-ส่วนปรับปรุงที่ดิน,1212020001,"bale[1212020001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212029990,374,[1212029990]ค่าเสื่อมสะสม-ส่วนปรับปรุงที่ดิน Interface,1212029990,"bale[1212029990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212030000,375,[1212030000]ค่าเสื่อมสะสม-อาคาร/ส่วนปรับปรุงอาคาร,1212030000,"bale[1212030000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212030001,376,[1212030001]ค่าเสื่อมสะสม-อาคาร,1212030001,"bale[1212030001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212030002,377,[1212030002]ค่าเสื่อมสะสม-อาคารชั่วคราว,1212030002,"bale[1212030002][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212030003,378,[1212030003]ค่าเสื่อมสะสม-สิ่งปลูกสร้าง,1212030003,"bale[1212030003][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212030004,379,[1212030004]ค่าเสื่อมสะสม-ส่วนปรับปรุงอาคาร,1212030004,"bale[1212030004][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212039990,380,[1212039990]ค่าเสื่อมสะสม-อาคาร Interface,1212039990,"bale[1212039990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212039991,381,[1212039991]ค่าเสื่อมสะสม-อาคารชั่วคราว Interface,1212039991,"bale[1212039991][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212039992,382,[1212039992]ค่าเสื่อมสะสม-สิ่งปลูกสร้าง Interface,1212039992,"bale[1212039992][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212039993,383,[1212039993]ค่าเสื่อมสะสม-ส่วนปรับปรุงอาคาร Interface,1212039993,"bale[1212039993][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212040000,384,[1212040000]ค่าเสื่อมสะสม-ครุภัณฑ์,1212040000,"bale[1212040000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212040001,385,[1212040001]ค่าเสื่อมสะสม-ครุภัณฑ์สำนักงาน,1212040001,"bale[1212040001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212040002,386,[1212040002]ค่าเสื่อมสะสม-ครุภัณฑ์วิทยาศาสตร์,1212040002,"bale[1212040002][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212040003,387,[1212040003]ค่าเสื่อมสะสม-ครุภัณฑ์โฆษณาและเผยแพร่,1212040003,"bale[1212040003][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212040004,388,[1212040004]ค่าเสื่อมสะสม-ครุภัณฑ์ไฟฟ้าและวิทยุ,1212040004,"bale[1212040004][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212040005,389,[1212040005]ค่าเสื่อมสะสม-ครุภัณฑ์คอมพิวเตอร์,1212040005,"bale[1212040005][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212040006,390,[1212040006]ค่าเสื่อมสะสม-ครุภัณฑ์งานบ้านงานครัว,1212040006,"bale[1212040006][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212040007,391,[1212040007]ค่าเสื่อมสะสม-ครุภัณฑ์การแพทย์,1212040007,"bale[1212040007][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212040008,392,[1212040008]ค่าเสื่อมสะสม-ครุภัณฑ์การเกษตร,1212040008,"bale[1212040008][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212040009,393,[1212040009]ค่าเสื่อมสะสม-ครุภัณฑ์กีฬา/ดนตรี-นาฏศิลป์,1212040009,"bale[1212040009][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212040010,394,[1212040010]ค่าเสื่อมสะสม-ครุภัณฑ์และอุปกรณ์ก่อสร้าง,1212040010,"bale[1212040010][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212049990,395,[1212049990]ค่าเสื่อมสะสม-ครุภัณฑ์สำนักงาน Interface,1212049990,"bale[1212049990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212049991,396,[1212049991]ค่าเสื่อมสะสม-ครุภัณฑ์วิทยาศาสตร์ Interface,1212049991,"bale[1212049991][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212049992,397,[1212049992]ค่าเสื่อมสะสม-ครุภัณฑ์โฆษณาและเผยแพร่ Interface,1212049992,"bale[1212049992][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212049993,398,[1212049993]ค่าเสื่อมสะสม-ครุภัณฑ์ไฟฟ้าและวิทยุ Interface,1212049993,"bale[1212049993][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212049994,399,[1212049994]ค่าเสื่อมสะสม-ครุภัณฑ์คอมพิวเตอร์ Interface,1212049994,"bale[1212049994][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212049995,400,[1212049995]ค่าเสื่อมสะสม-ครุภัณฑ์งานบ้านงานครัว Interface,1212049995,"bale[1212049995][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212049996,401,[1212049996]ค่าเสื่อมสะสม-ครุภัณฑ์การแพทย์ Interface,1212049996,"bale[1212049996][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212049997,402,[1212049997]ค่าเสื่อมสะสม-ครุภัณฑ์การเกษตร Interface,1212049997,"bale[1212049997][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212049998,403,[1212049998]ค่าเสื่อมสะสม-ครุภัณฑ์กีฬา/ดนตรี-นาฏศิลป์ Interface,1212049998,"bale[1212049998][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212049999,404,[1212049999]ค่าเสื่อมสะสม-ครุภัณฑ์และอุปกรณ์ก่อสร้าง Interface,1212049999,"bale[1212049999][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212050000,405,[1212050000]ค่าเสื่อมสะสม-ยานพาหนะ,1212050000,"bale[1212050000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212050001,406,[1212050001]ค่าเสื่อมสะสม-ยานพาหนะ,1212050001,"bale[1212050001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212059990,407,[1212059990]ค่าเสื่อมสะสม-ยานพาหนะ Interface,1212059990,"bale[1212059990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212060000,408,[1212060000]ค่าตัดจำหน่ายสะสม-สินทรัพย์ไม่มีตัวตน,1212060000,"bale[1212060000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212060001,409,[1212060001]ค่าตัดจำหน่ายสะสม-สินทรัพย์ไม่มีตัวตน,1212060001,"bale[1212060001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212069990,410,[1212069990]ค่าตัดจำหน่ายสะสม-สินทรัพย์ไม่มีตัวตน Interface,1212069990,"bale[1212069990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212070000,411,[1212070000]ค่าเสื่อมราคาสะสม-สินทรัพย์ตามสัญญาเช่าการเงิน,1212070000,"bale[1212070000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1212070001,412,[1212070001]ค่าเสื่อมราคาสะสม-สินทรัพย์ตามสัญญาเช่าการเงิน,1212070001,"bale[1212070001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1213000000,413,[1213000000]สินทรัพย์ระหว่างก่อสร้าง,1213000000,"bale[1213000000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1213010001,414,[1213010001]สินทรัพย์ระหว่างก่อสร้าง-อาคาร,1213010001,"bale[1213010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1213010002,415,[1213010002]สินทรัพย์ระหว่างก่อสร้าง-ค่าควบคุมงาน,1213010002,"bale[1213010002][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1213010003,416,[1213010003]สินทรัพย์ระหว่างก่อสร้าง-ค่าออกแบบอาคาร,1213010003,"bale[1213010003][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1213010004,417,[1213010004]สินทรัพย์ระหว่างก่อสร้าง-ครุภัณฑ์อื่นๆ,1213010004,"bale[1213010004][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1213019990,418,[1213019990]สินทรัพย์ระหว่างก่อสร้าง-อาคาร Interface,1213019990,"bale[1213019990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1213019991,419,[1213019991]สินทรัพย์ระหว่างก่อสร้าง-ค่าควบคุมงาน Interface,1213019991,"bale[1213019991][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1213019992,420,[1213019992]สินทรัพย์ระหว่างก่อสร้าง-ค่าออกแบบอาคาร Interface,1213019992,"bale[1213019992][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1213019993,421,[1213019993]สินทรัพย์ระหว่างก่อสร้าง-ติดตั้งเครื่องจักร Interface,1213019993,"bale[1213019993][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1214000000,422,[1214000000]สินทรัพย์ระหว่างทาง,1214000000,"bale[1214000000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1214010001,423,[1214010001]สินทรัพย์ระหว่างทาง,1214010001,"bale[1214010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1214010002,424,[1214010002]พักครุภัณฑ์,1214010002,"bale[1214010002][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1214010003,425,[1214010003]Down payment พักครุภัณฑ์,1214010003,"bale[1214010003][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1214010004,426,[1214010004]Clearing down payment พักครุภัณฑ์,1214010004,"bale[1214010004][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1214010005,427,[1214010005]ค่าเสื่อมสะสม-พักครุภัณฑ์,1214010005,"bale[1214010005][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1214019990,428,[1214019990]สินทรัพย์ระหว่างทาง-INTERFACE,1214019990,"bale[1214019990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1290000000,429,[1290000000]สินทรัพย์ไม่หมุนเวียนอื่น,1290000000,"bale[1290000000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1290010001,430,[1290010001]เงินกู้ยืมพนักงานผู้ประสบภัยธรรมชาติ,1290010001,"bale[1290010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1290010002,431,[1290010002]ลูกหนี้ระหว่างบังคับคดี,1290010002,"bale[1290010002][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1290010003,432,[1290010003]ดอกเบี้ยจ่ายรอการรับรู้,1290010003,"bale[1290010003][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1290019990,433,[1290019990]ลูกหนี้ระหว่างรอบังคับคดี Interface,1290019990,"bale[1290019990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th1290019900,434,[1290019900]สินทรัพย์ไม่หมุนเวียนอื่น,1290019900,"bale[1290019900][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2000000000,435,[2000000000]หนี้สิน,2000000000,"bale[2000000000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2100000000,436,[2100000000]หนี้สินหมุนเวียน,2100000000,"bale[2100000000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2101010000,437,[2101010000]เจ้าหนี้การค้า,2101010000,"bale[2101010000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2101010001,438,[2101010001]เจ้าหนี้การค้า - ในประเทศ,2101010001,"bale[2101010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2101010002,439,[2101010002]เจ้าหนี้การค้า - ต่างประเทศ,2101010002,"bale[2101010002][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2101010003,440,[2101010003]GR-IR (เจ้าหนี้การค้า),2101010003,"bale[2101010003][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2101010004,441,[2101010004]เจ้าหนี้ฝากขายหนังสือ (Consignment),2101010004,"bale[2101010004][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2101019990,442,[2101019990]เจ้าหนี้การค้า-ในประเทศ Interface,2101019990,"bale[2101019990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2101019991,443,[2101019991]เจ้าหนี้การค้า-ต่างประเทศ Interface,2101019991,"bale[2101019991][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2102010000,444,[2102010000]เจ้าหนี้อื่น,2102010000,"bale[2102010000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2102010001,445,[2102010001]เจ้าหนี้หน่วยบริการ,2102010001,"bale[2102010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2102019992,446,[2102019992]เจ้าหนี้อื่น Interface,2102019992,"bale[2102019992][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2102010002,447,[2102010002]เงินรอรับรู้,2102010002,"bale[2102010002][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2102019991,448,[2102019991]เงินรอรับรู้ Interface,2102019991,"bale[2102019991][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2102019900,449,[2102019900]เจ้าหนี้อื่น,2102019900,"bale[2102019900][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2102019990,450,[2102019990]เจ้าหนี้หน่วยบริการ Interface,2102019990,"bale[2102019990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2103010000,451,[2103010000]ค่าใช้จ่ายค้างจ่าย,2103010000,"bale[2103010000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2103010001,452,[2103010001]ค่าใช้จ่ายค้างจ่าย,2103010001,"bale[2103010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2103019990,453,[2103019990]ค่าใช้จ่ายค้างจ่าย Interface,2103019990,"bale[2103019990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2104010000,454,[2104010000]รายได้รับล่วงหน้า,2104010000,"bale[2104010000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2104010001,455,[2104010001]รายได้รับล่วงหน้า,2104010001,"bale[2104010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2104019990,456,[2104019990]รายได้รับล่วงหน้า Interface,2104019990,"bale[2104019990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2105010000,457,[2105010000]เงินค้างนำส่ง,2105010000,"bale[2105010000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2105010001,458,[2105010001]เงินกองทุนสำรองเลี้ยงชีพ,2105010001,"bale[2105010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2105010002,459,[2105010002]ภาษีเงินได้บุคคลธรรมดาหัก ณ ที่จ่าย,2105010002,"bale[2105010002][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2105010003,460,[2105010003]ภาษีเงินได้นิติบุคคลหัก ณ ที่จ่าย,2105010003,"bale[2105010003][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2106010000,461,[2106010000]ภาษีขาย,2106010000,"bale[2106010000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2106010001,462,[2106010001]ภาษีขาย,2106010001,"bale[2106010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2106010002,463,[2106010002]พักภาษีขาย,2106010002,"bale[2106010002][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2106019990,464,[2106019990]พักภาษีขาย Interface,2106019990,"bale[2106019990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2107010000,465,[2107010000]เงินงบประมาณกันเบิกเหลื่อมปี,2107010000,"bale[2107010000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2107010001,466,[2107010001]เงินงบประมาณกันเบิกเหลื่อมปี,2107010001,"bale[2107010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2107019990,467,[2107019990]เงินงบประมาณกันเบิกเหลื่อมปี Interface,2107019990,"bale[2107019990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2190010000,468,[2190010000]หนี้สินหมุนเวียนอื่น,2190010000,"bale[2190010000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2190010001,469,[2190010001]รายได้รอการรับรู้,2190010001,"bale[2190010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2190019990,470,[2190019990]รายได้รอการรับรู้ Interface,2190019990,"bale[2190019990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2190019900,471,[2190019900]หนี้สินหมุนเวียนอื่น,2190019900,"bale[2190019900][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2200000000,472,[2200000000]หนี้สินไม่หมุนเวียน,2200000000,"bale[2200000000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2201010000,473,[2201010000]เงินสำรองรอจ่าย,2201010000,"bale[2201010000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2201010001,474,[2201010001]เงินบำเหน็จพนักงาน สวทช. รอจ่าย,2201010001,"bale[2201010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2201019990,475,[2201019990]เงินบำเหน็จพนักงาน สวทช. รอจ่าย Interface,2201019990,"bale[2201019990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2201010002,476,[2201010002]เงินค่าสมนาคุณ สวทช. รอจ่าย,2201010002,"bale[2201010002][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2201019991,477,[2201019991]เงินค่าสมนาคุณ สวทช. รอจ่าย Interface,2201019991,"bale[2201019991][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2202010000,478,[2202010000]หนี้สินตามสัญญาเช่าการเงิน,2202010000,"bale[2202010000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2202010001,479,[2202010001]หนี้สินตามสัญญาเช่าการเงิน,2202010001,"bale[2202010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2202019990,480,[2202019990]หนี้สินตามสัญญาเช่าการเงิน Interface,2202019990,"bale[2202019990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2203010000,481,[2203010000]เงินมัดจำ/เงินค้ำประกัน,2203010000,"bale[2203010000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2203010001,482,[2203010001]เงินมัดจำรับ-ค่าเช่าสำนักงาน,2203010001,"bale[2203010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2203019990,483,[2203019990]เงินมัดจำรับ-ค่าเช่าสำนักงาน Interface,2203019990,"bale[2203019990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2203010002,484,[2203010002]เงินมัดจำรับ-ค่าบริการส่วนกลาง,2203010002,"bale[2203010002][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2203019991,485,[2203019991]เงินมัดจำรับ-ค่าบริการส่วนกลาง Interface,2203019991,"bale[2203019991][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2203010003,486,[2203010003]เงินมัดจำรับ-ค่าตกแต่งพื้นที่,2203010003,"bale[2203010003][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2203010004,487,[2203010004]เงินมัดจำรับ-ค่าเช่าป้าย,2203010004,"bale[2203010004][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2203019993,488,[2203019993]เงินมัดจำรับ-ค่าเช่าป้าย Interface,2203019993,"bale[2203019993][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2203010005,489,[2203010005]เงินมัดจำรับ-อื่น,2203010005,"bale[2203010005][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2203019994,490,[2203019994]เงินมัดจำรับ-อื่น Interface,2203019994,"bale[2203019994][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2203010006,491,[2203010006]เงินค้ำประกันรับ-สัญญา,2203010006,"bale[2203010006][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2203010007,492,[2203010007]เงินค้ำประกันรับ-ผลงาน,2203010007,"bale[2203010007][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2203010008,493,[2203010008]เงินค้ำประกันรับอื่น,2203010008,"bale[2203010008][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2203019992,494,[2203019992]เงินมัดจำรับ-ค่าตกแต่งพื้นที่ Interface,2203019992,"bale[2203019992][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2203019995,495,[2203019995]เงินค้ำประกันรับ-สัญญา Interface,2203019995,"bale[2203019995][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2203019996,496,[2203019996]เงินค้ำประกันรับ-ผลงาน Interface,2203019996,"bale[2203019996][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2203019997,497,[2203019997]เงินค้ำประกันรับอื่น Interface,2203019997,"bale[2203019997][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2204010000,498,[2204010000]รายได้เงินอุดหนุนรอการรับรู้,2204010000,"bale[2204010000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2204010100,499,[2204010100]รายได้รอการรับรู้ - รอบังคับคดี,2204010100,"bale[2204010100][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2204019990,500,[2204019990]รายได้รอการรับรู้ - รอบังคับคดี Interface,2204019990,"bale[2204019990][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2290010000,501,[2290010000]หนี้สินไม่หมุนเวียนอื่น,2290010000,"bale[2290010000][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th2290019900,502,[2290019900]หนี้สินไม่หมุนเวียนอื่น,2290019900,"bale[2290019900][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th3000000000,503,[3000000000]เงินกองทุน (ส่วนของเจ้าของ),3000000000,"bale[3000000000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th3101010000,504,[3101010000]ทุน,3101010000,"bale[3101010000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th3101010001,505,[3101010001]ทุนประเดิมของ สวทช.,3101010001,"bale[3101010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th3101010002,506,[3101010002]ทุนรับโอน-โครงการวิทยาศาสตร์และเทคโนโลยีฯ (STDB),3101010002,"bale[3101010002][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th3101010003,507,[3101010003]ทุนรับโอน-สำนักงานปลัดกระทรวง กระทรวงวิทย์,3101010003,"bale[3101010003][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th3101010004,508,[3101010004]ทุนรับโอน-สวทช.,3101010004,"bale[3101010004][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th3101010005,509,[3101010005]ทุนรับโอน-NECTEC,3101010005,"bale[3101010005][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th3101010006,510,[3101010006]ทุนรับโอนอื่น,3101010006,"bale[3101010006][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th3101010007,511,[3101010007]ทุนที่โอนออก-สวทน.,3101010007,"bale[3101010007][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th3101010008,512,[3101010008]ทุนที่โอนออก-ADTEC,3101010008,"bale[3101010008][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th3101010009,513,[3101010009]ทุนที่โอนออกอื่น,3101010009,"bale[3101010009][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th3101010010,514,[3101010010]ทุนรับโอนโครงการพิเศษทุนประเดิม,3101010010,"bale[3101010010][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th3201010000,515,[3201010000]ส่วนเกินทุนจากการบริจาค,3201010000,"bale[3201010000][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th3201010001,516,[3201010001]ส่วนเกินทุนจากการบริจาค,3201010001,"bale[3201010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th3301010000,517,[3301010000]รายได้สูงกว่า(ต่ำกว่า)ค่าใช้จ่ายสะสม,3301010000,"bale[3301010000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th3301010001,518,[3301010001]รายได้สูงกว่า (ต่ำกว่า) ค่าใช้จ่ายสะสม,3301010001,"bale[3301010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+mis_report_bs_internal_th3301010002,519,[3301010002]กำไร/ขาดทุน ที่ยังไม่เกิดขึ้นในหลักทรัพย์เผื่อขาย,3301010002,"bale[3301010002][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
+,,,,,,,,,,,
+mis_report_bs_external_th1000000000,1,[1000000000]สินทรัพย์,1000000000,"bale[1000000000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1100000000,2,[1100000000]สินทรัพย์หมุนเวียน,1100000000,"bale[1100000000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101000000,3,[1101000000]เงินสดและรายการเทียบเท่าเงินสด,1101000000,"bale[1101000000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101010000,4,[1101010000]เงินสด,1101010000,"bale[1101010000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101010001,5,[1101010001]เงินสดย่อย,1101010001,"bale[1101010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101010002,6,[1101010002]เงินสดในมือ,1101010002,"bale[1101010002][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101010003,7,[1101010003]เช็ครับ,1101010003,"bale[1101010003][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101019990,8,[1101019990]เงินสดในมือ Interface,1101019990,"bale[1101019990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101020000,9,[1101020000]เงินฝากธนาคาร-ออมทรัพย์,1101020000,"bale[1101020000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101020001,10,[1101020001]KTB CA 152-6-00424-0 สวทช.-เงินในงบประมาณ,1101020001,"bale[1101020001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101020002,11,[1101020002]KTB CA 152-6-00426-7 สวทช.-เงินนอกงบประมาณ,1101020002,"bale[1101020002][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101020003,12,[1101020003]KTB CA 152-6-00469-0 สวทช.-เงินเบิกแทนกัน,1101020003,"bale[1101020003][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101020004,13,[1101020004]KTB SA 152-1-32668-1 CA 152-6-00244-2 สวทช.,1101020004,"bale[1101020004][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101020005,14,[1101020005]KTB SA 013-1-51385-0 CA 013-6-08136-3 สถาบันวิทยาการ,1101020005,"bale[1101020005][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101020006,15,[1101020006]KTB SA 152-1-32670-3 CA 152-6-00245-0 นักเรียนทุน,1101020006,"bale[1101020006][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101020007,16,[1101020007]BBL SA 080-0-00001-0 CA 080-3-00001-7 สวทช.,1101020007,"bale[1101020007][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101020008,17,[1101020008]BBL SA 080-0-01855-8 CA 080-3-00074-4 ศน.,1101020008,"bale[1101020008][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101020009,18,[1101020009]BBL SA 080-0-00279-2 CA 080-3-00008-2 ศช.,1101020009,"bale[1101020009][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101020010,19,[1101020010]BBL SA 080-0-00280-0 CA 080-3-00009-0 รายได้-ศช.,1101020010,"bale[1101020010][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101020011,20,[1101020011]BBL SA 080-0-00084-6 CA 080-3-00003-3 ศว.,1101020011,"bale[1101020011][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101020012,21,[1101020012]BBL SA 080-0-00178-6 รายได้-MTEC,1101020012,"bale[1101020012][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101020013,22,[1101020013]BBL SA 080-0-04444-8 CA 080-3-00118-9 ศอ.,1101020013,"bale[1101020013][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101020014,23,[1101020014]BBL SA 759-0-26380-7 ศช. ห้องปฏิบัติการสรีรวิทยาสัตว์,1101020014,"bale[1101020014][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101020015,24,[1101020015]SCB SA 324-2-56262-0 CA 324-3-03140-2 ซอฟต์แวร์#2,1101020015,"bale[1101020015][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101020016,25,[1101020016]SCB SA 667-2-15866-7 CA 667-3-00344-1 สวทช. ภาคเหนือ,1101020016,"bale[1101020016][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101020017,26,[1101020017]SCB SA 541-2-30920-2 CA 541-3-00951-2 ศวพก.,1101020017,"bale[1101020017][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101020018,27,[1101020018]TMB SA 069-2-19922-7 หน่วยฯ แป้ง (รายได้),1101020018,"bale[1101020018][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101020019,28,[1101020019]BAY SA 329-1-34850-3 CA 329-0-01347-6 ซอฟต์แวร์#2,1101020019,"bale[1101020019][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101020020,29,[1101020020]BBL SA 080-0-07531-9 CA 080-3-00162-7 กฟผ.-สวทช.,1101020020,"bale[1101020020][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101020021,30,[1101020021]BBL CA101-3-15558-3สนง.คณะกรรมการพัฒนาวิทยาศาสตร์ฯ,1101020021,"bale[1101020021][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101020022,31,[1101020022]KTB CA 475-6-00353-2 โครงการเงินกู้เพื่อพัฒนาระบบ,1101020022,"bale[1101020022][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101020023,32,[1101020023]BBL SA 080-0-12726-8 CA 080-3-00274-0  CTEC,1101020023,"bale[1101020023][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101020024,33,[1101020024]BBL SA 080-0-04983-5 CA 080-3-00121-3  DECC,1101020024,"bale[1101020024][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101020025,34,[1101020025]BBL SA 080-0-13324-1 เงินบริจาคกองทุนพัฒนาวิทยาศาสตร์,1101020025,"bale[1101020025][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101029990,35,[1101029990]เงินฝากธนาคาร-ออมทรัพย์ Interface,1101029990,"bale[1101029990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101030000,36,[1101030000]เงินฝากธนาคาร-ประจำ 3 เดือน,1101030000,"bale[1101030000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101030001,37,[1101030001]GSB SA 3-001798250-9 [3 เดือน] สวทช.,1101030001,"bale[1101030001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101030002,38,[1101030002]BBL FA 080-2-01168-4 [14 วัน] สวทช.,1101030002,"bale[1101030002][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101030003,39,[1101030003]TNC FA 482-1-10953-6 [1 เดือน] สวทช.,1101030003,"bale[1101030003][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101030004,40,[1101030004]BAY FA 669-2-01017-8 [2 เดือน] สวทช.,1101030004,"bale[1101030004][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101030005,41,[1101030005]SCB FA 464-018272-9 สวทช.,1101030005,"bale[1101030005][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101039990,42,[1101039990]เงินฝากธนาคาร-ประจำ Interface,1101039990,"bale[1101039990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101040000,43,[1101040000]เงินฝากธนาคารที่มีวัตถุประสงค์เฉพาะ,1101040000,"bale[1101040000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050000,44,[1101050000]เงินฝากธนาคารที่มีวัตถุประสงค์เฉพาะ-สกสว.,1101050000,"bale[1101050000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050001,45,[1101050001]BBL SA 080-0-10037-2 CA 080-3-00215-3 ทุนวิจัย สกว.-สวทช.,1101050001,"bale[1101050001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050002,46,[1101050002]BBL SA 080-0-11452-2 CA 080-3-00251-8 TRG58-กรกช,1101050002,"bale[1101050002][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050003,47,[1101050003]BBL SA 080-0-11551-1 CA 080-3-00257-5 RSA58-ชัยรัตน์,1101050003,"bale[1101050003][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050004,48,[1101050004]BBL SA 080-0-11555-2 CA 080-3-00259-1 BRG58-ปิติ,1101050004,"bale[1101050004][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050005,49,[1101050005]BBL SA 080-0-11556-0 CA 080-3-00260-9 RSA58-ศิษเฎศ,1101050005,"bale[1101050005][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050006,50,[1101050006]BBL SA 080-0-11576-8 CA 080-3-00262-5 RSA58-เปรมฤทัย,1101050006,"bale[1101050006][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050007,51,[1101050007]BBL SA 080-0-11755-8 CA 080-3-00272-4 TN-มาซาฮิโกะ,1101050007,"bale[1101050007][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050008,52,[1101050008]BBL SA 080-0-11894-5 CA 080-3-00276-5 RDG5850103-พิมพา,1101050008,"bale[1101050008][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050009,53,[1101050009]KTB SA 475-3-20610-6 CA 475-6-00500-4 ทุนวิจัย สกว,1101050009,"bale[1101050009][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050010,54,[1101050010]BBL SA 080-0-13037-9 CA 080-3-00336-7 เศรษฐลัทธ์,1101050010,"bale[1101050010][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050011,55,[1101050011]BBL SA 080-0-12002-4 CA 080-3-00286-4 TN-คทาวุธ,1101050011,"bale[1101050011][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050012,56,[1101050012]BBL SA 080-0-12003-2 CA 080-3-00287-2 TN-สินีนาฏ,1101050012,"bale[1101050012][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050013,57,[1101050013]BBL SA 080-0-12004-0 CA 080-3-00288-0 TN-นพดล,1101050013,"bale[1101050013][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050014,58,[1101050014]BBL SA 080-0-12365-5 CA 080-3-00297-1 TN-วัชริน ม.,1101050014,"bale[1101050014][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050015,59,[1101050015]BBL SA 080-0-12377-0 CA 080-3-00301-1 TN-อัยดา อ.,1101050015,"bale[1101050015][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050016,60,[1101050016]BBL SA 080-0-12374-7 CA 080-3-00298-9 TN-จีราพร ล.,1101050016,"bale[1101050016][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050017,61,[1101050017]BBL SA 080-0-12375-4 CA 080-3-00299-7 TN-สัญชัย ค.,1101050017,"bale[1101050017][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050018,62,[1101050018]BBL SA 080-0-12376-2 CA 080-3-00300-3 TN-สุวัสสา บ,1101050018,"bale[1101050018][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050019,63,[1101050019]BBL SA 080-0-12402-6 CA 080-3-00306-0 TN-ธริดาพร บ,1101050019,"bale[1101050019][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050020,64,[1101050020]BBL SA 080-0-12405-9 CA 080-3-00309-4 TN-สุธา ส.,1101050020,"bale[1101050020][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050021,65,[1101050021]BBL SA 080-0-12403-4 CA 080-3-00307-8 TN-ชลรัชต์ บ,1101050021,"bale[1101050021][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050022,66,[1101050022]BBL SA 080-0-12404-2 CA 080-3-00308-6 TN-ศันสนีย น,1101050022,"bale[1101050022][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050023,67,[1101050023]BBL SA 080-0-12388-7 CA 080-3-003037 TN-ขจรศักดิ์,1101050023,"bale[1101050023][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050024,68,[1101050024]BBL SA 080-0-12428-1 CA 080-3-00311-0 TN-กัลยาณ์ ศ.,1101050024,"bale[1101050024][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050025,69,[1101050025]BBL SA 080-0-12508-0 CA 080-3-00312-8 TN-ณัฐกา ส.,1101050025,"bale[1101050025][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050026,70,[1101050026]BBL SA 080-0-12509-8 CA 080-3-00313-6 TN-ชญาภา น.,1101050026,"bale[1101050026][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050027,71,[1101050027]BBL SA 080-0-12511-4 CA 080-3-00315-1 TN-อนุชา ว.,1101050027,"bale[1101050027][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050028,72,[1101050028]BBL SA 080-0-12642-7 CA 080-3-00319-3 TN-วีระวัฒน์,1101050028,"bale[1101050028][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050029,73,[1101050029]BBL SA 080-0-12643-5 CA 080-3-00320-1 TN-จักรพล,1101050029,"bale[1101050029][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050030,74,[1101050030]BBL SA 080-0-12677-3 CA 080-3-00321-9 TN-ชัยยันต์,1101050030,"bale[1101050030][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050031,75,[1101050031]BBL SA 080-0-12683-1 CA 080-3-00322-7 TN-พรพรรณ,1101050031,"bale[1101050031][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050032,76,[1101050032]BBL SA 080-0-12693-0 CA 080-3-00324-3 TN-ไพศาล,1101050032,"bale[1101050032][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050033,77,[1101050033]BBL SA 080-0-12695-5 CA 080-3-00325-0 TN- ยศวัต,1101050033,"bale[1101050033][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050034,78,[1101050034]BBL SA 080-0-11959-6 CA 080-3-00282-3 TN-สิรินาถ,1101050034,"bale[1101050034][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050035,79,[1101050035]KTB SA 475-3-09516-9 CA 475-6-00419-9 TN-อุรชา ร.,1101050035,"bale[1101050035][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050036,80,[1101050036]KTB SA 475-3-14302-3 CA 475-6-00462-8 TN-เทพชัย,1101050036,"bale[1101050036][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050037,81,[1101050037]KTB SA 475-3-19784-0 CA 475-6-00485-7 TN-ธงชัย ก.,1101050037,"bale[1101050037][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050038,82,[1101050038]BBL SA 080-0-11961-2 CA 080-3-00284-9 TN-ปัทมา,1101050038,"bale[1101050038][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050039,83,[1101050039]BBL SA 080-0-13120-3 CA 080-3-00341-7 TN-กิตติพงษ์,1101050039,"bale[1101050039][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050040,84,[1101050040]BBL SA 080-0-13122-9 CA 080-3-00343-3 TN-ธิติกร,1101050040,"bale[1101050040][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050041,85,[1101050041]BBL SA 080-0-13149-2 CA 080-3-00346-6 TN-อัญชลี,1101050041,"bale[1101050041][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050042,86,[1101050042]BBL SA 080-0-12692-2 CA 080-3-00323-5 TN-นิทัศน์ (DECC),1101050042,"bale[1101050042][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050043,87,[1101050043]BBL SA 080-0-13258-1 CA 080-3-00347-4 PT-ปัทมา,1101050043,"bale[1101050043][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050053,88,[1101050053]BBL SA 080-0-13413-2 CA 080-3-00359-9 TN-ณรงค์ พ.50026,1101050053,"bale[1101050053][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050054,89,[1101050054]BBL SA 080-0-13426-4 CA 080-3-00360-7 TN-ศราวุธ ล.50032,1101050054,"bale[1101050054][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050055,90,[1101050055]BBL SA 080-0-13455-3 CA 080-3-00361-5 TN-ปัทมา พ.20019,1101050055,"bale[1101050055][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050056,91,[1101050056]BBL SA 080-0-13482-7 CA 080-3-00362-3 TN-ศราวุธ ล.50039,1101050056,"bale[1101050056][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050057,92,[1101050057]BBL SA 080-013541-0 CA 080-3-00363-1 โรคติดเชื้อในสัตว์,1101050057,"bale[1101050057][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050044,93,[1101050044]BBL SA 080-0-13301-9 CA 080-3-00350-8 TN-วรรณพ.ว.50009,1101050044,"bale[1101050044][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050045,94,[1101050045]BBL SA 080-0-13298-7 CA 080-3-00348-2 TN-วรรณพ.ว.50006,1101050045,"bale[1101050045][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050046,95,[1101050046]BBL SA 080-0-13299-5 CA 080-3-00349-0 TN-วรรณพ.ว.50008,1101050046,"bale[1101050046][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050047,96,[1101050047]BBL SA 080-0-13302-7 CA 080-3-00351-6 TN-เกื้อกูล.ป.50002,1101050047,"bale[1101050047][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050048,97,[1101050048]BBL SA 080-0-13311-8 CA 080-3-00355-7 TN-วรรณพ.ว.50003,1101050048,"bale[1101050048][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050049,98,[1101050049]BBL SA 080-0-13308-4 CA 080-3-00352-4 TN-วรรณพ.ว.50004,1101050049,"bale[1101050049][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050050,99,[1101050050]BBL SA 080-0-13309-2 CA 080-3-00353-2 TN-วรรณพ.ว.50005,1101050050,"bale[1101050050][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050051,100,[1101050051]BBL SA 080-0-13310-0 CA 080-3-00354-0 'TN-วรรณพ.ว.50007,1101050051,"bale[1101050051][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101050052,101,[1101050052]BBL SA 080-0-13326-6 CA 080-3-00357-3 TN-วรรณพ.ว.50010,1101050052,"bale[1101050052][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101060000,102,[1101060000]เงินฝากธนาคารที่มีวัตถุประสงค์เฉพาะ-สวก.,1101060000,"bale[1101060000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101060001,103,[1101060001]KTB SA 475-0-88623-8 CA 475-6-00303-6 ผลิตเม็ดพันธุ์,1101060001,"bale[1101060001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101060003,104,[1101060003]BBL SA 080-0-12390-3 CA 080-3-00305-2 อาหารกุ้ง,1101060003,"bale[1101060003][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101060004,105,[1101060004]BBL SA 080-0-12389-5 CA 080-3-00304-5ต้านการอักเสบ,1101060004,"bale[1101060004][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101060005,106,[1101060005]BBL SA 080-0-12406-7 CA 080-3-00310-2 ข้าวทนหนาว,1101060005,"bale[1101060005][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101060006,107,[1101060006]BBL SA 080-0-12512-2 CA 080-3-00316-9 สิ่งทอไล่ยุง,1101060006,"bale[1101060006][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101060007,108,[1101060007]BBL SA 080-0-12510-6 CA 080-3-00314-4 จำแนกสปีชีส์,1101060007,"bale[1101060007][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101060008,109,[1101060008]KTB SA 475-3-08198-2 CA 475-6-00414-8 สีผิวผลปาล์ม,1101060008,"bale[1101060008][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101060009,110,[1101060009]KTB SA 475-3-10171-1 CA 475-6-00432-6 เมทาโบไลท์,1101060009,"bale[1101060009][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101060010,111,[1101060010]KTB SA 475-3-10170-3 CA 475-6-00431-8 โปรตีโอมิกส์,1101060010,"bale[1101060010][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101060011,112,[1101060011]KTB SA 475-3-10410-9 CA 475-6-00437-7 ตรวจมะละกอ,1101060011,"bale[1101060011][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101060014,113,[1101060014]KTB SA 475-3-10748-5 CA 475-6-00450-4 เนื้อเยื่อ,1101060014,"bale[1101060014][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101060015,114,[1101060015]KTB SA 475-3-19732-8 CA 475-6-00483-0 ข้าวลูกผสม#3,1101060015,"bale[1101060015][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101060016,115,[1101060016]KTB SA 475-3-19733-6 CA 475-6-00484-9 พิมพ์ DNA#3,1101060016,"bale[1101060016][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101060017,116,[1101060017]KTB SA 475-3-20777-3 CA 475-6-00502-0 การประยุกต์,1101060017,"bale[1101060017][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101060018,117,[1101060018]KTB SA 475-3-21238-6 CA 475-6-00519-5 การประเมิน,1101060018,"bale[1101060018][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101060019,118,[1101060019]KTB SA 475-3-21824-4 CA 475-6-00549-7 มะพร้าวไทย,1101060019,"bale[1101060019][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101060020,119,[1101060020]KTB SA 475-3-21840-6 CA 475-6-00550-0 พันธุกรรมข้าว,1101060020,"bale[1101060020][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101060021,120,[1101060021]KTB SA 475-3-21839-2 CA 475-6-00551-9 ข้าวเรณู,1101060021,"bale[1101060021][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101060022,121,[1101060022]KTB SA 475-3-21867-8 CA 475-6-00552-7 แม่เป็นหมัน,1101060022,"bale[1101060022][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101060023,122,[1101060023]KTB SA 475-3-21894-5 CA 475-6-00553-5 การปลูกอ้อย,1101060023,"bale[1101060023][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101060024,123,[1101060024]KTB SA 475-3-30630-5 CA 475-6-00561-6  นิวคลีโอไทด์,1101060024,"bale[1101060024][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101060025,124,[1101060025]KTB SA 475-3-31608-4 CA 475-6-00572-1  ปลากัดไทย,1101060025,"bale[1101060025][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101060026,125,[1101060026]KTB SA 475-3-31624-6 CA 475-6-00574-8  โรคในปลานิล,1101060026,"bale[1101060026][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101060027,126,[1101060027]KTB SA 475-3-31625-4 CA 475-6-00575-6  เมล็ดพริก,1101060027,"bale[1101060027][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101060028,127,[1101060028]BBL SA 080-0-11748-3 CA 080-3-00271-6 โรงเรือนกล้วยไม้ (DECC),1101060028,"bale[1101060028][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101060029,128,[1101060029]KTB SA 475-3-31713-7 CA 475-6-00578-0 ผลิตภัณฑ์สุกร,1101060029,"bale[1101060029][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101060030,129,[1101060030]KTB SA 475-3-31956-3 CA 475-6-00580-2 โรคใบขาวของอ้อย,1101060030,"bale[1101060030][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101060031,130,[1101060031]KTB SA 475-3-32011-1 CA 475-6-00583-7 กุ้งขาวแวนนาไม,1101060031,"bale[1101060031][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101060032,131,[1101060032]KTB SA 475-3-32032-4 CA 475-6-00584-5 สไปรูลินา,1101060032,"bale[1101060032][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101060033,132,[1101060033]KTB SA 475-3-32078-2 CA 475-6-00585-3 อาหารกุ้ง (ปีที่ ๒),1101060033,"bale[1101060033][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101060034,133,[1101060034]KTB SA 475-3-32218-1 CA 475-6-00595-0 เชื้อ EHP ในกุ้งขาว,1101060034,"bale[1101060034][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101060035,134,[1101060035]KTB SA 475-3-32271-8 CA 475-6-00596-9 เรณูเป็นหมัน,1101060035,"bale[1101060035][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101060036,135,[1101060036]KTB SA 475-3-32603-9 CA 475-6-00608-6 ขยายพันธุ์ปาล์ม (ปีที่ 3),1101060036,"bale[1101060036][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101060037,136,[1101060037]KTB SA 475-3-39835-8 CA 475-6-00612-4 ความสุกของปาล์ม (ปีที่ 2),1101060037,"bale[1101060037][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101060038,137,[1101060038]KTB SA 475-3-41696-8 CA 475-6-00622-1 พัฒนาฐานข้อมูล,1101060038,"bale[1101060038][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101070000,138,[1101070000]เงินฝากธนาคารที่มีวัตถุประสงค์เฉพาะ-สสส.,1101070000,"bale[1101070000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101070001,139,[1101070001]BBL SA 080-0-12334-1 CA 080-3-00294-8 ผู้สูงอายุ,1101070001,"bale[1101070001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101080000,140,[1101080000]เงินฝากธนาคารที่มีวัตถุประสงค์เฉพาะ-วช.,1101080000,"bale[1101080000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101080002,141,[1101080002]KTB SA 475-0-64783-7 CA 475-6-00181-5 ศช. (การพัฒนาคุณภาพของผลมะละกอฯ),1101080002,"bale[1101080002][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101080003,142,[1101080003]KTB SA 475-0-76367-5 CA 475-6-00215-3 สำปะหลัง วช.56,1101080003,"bale[1101080003][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101080004,143,[1101080004]KTB SA 475-0-76369-1 CA 475-6-00216-1 ระบบราง วช.56,1101080004,"bale[1101080004][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101080005,144,[1101080005]KTB SA 475-0-78591-1 CA 475-6-00253-6 สำปะหลัง วช.57,1101080005,"bale[1101080005][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101080006,145,[1101080006]KTB SA 475-0-79325-6 CA 475-6-00258-7 ระบบราง วช.57,1101080006,"bale[1101080006][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101080007,146,[1101080007]KTB SA 475-0-88852-4 CA 475-6-00317-6 ลดมลพิษ,1101080007,"bale[1101080007][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101080008,147,[1101080008]KTB SA 475-0-88875-3 CA 475-6-00318-4 สำปะหลัง วช.58,1101080008,"bale[1101080008][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101080009,148,[1101080009]KTB SA 475-0-88878-8 CA 475-6-00319-2 ระบบราง วช.58,1101080009,"bale[1101080009][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101080010,149,[1101080010]KTB SA 475-0-89246-7 CA 475-6-00327-3 ชนิดดูดซึม,1101080010,"bale[1101080010][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101080011,150,[1101080011]KTB SA 475-0-89362-5 CA 475-6-00333-8 กุ้งตายด่วน,1101080011,"bale[1101080011][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101080012,151,[1101080012]KTB SA 475-0-89395-1 CA 475-6-00336-2 ตั๊กแตน,1101080012,"bale[1101080012][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101080013,152,[1101080013]KTB SA 475-0-97573-7 CA 475-6-00349-4 วัสดุนาโน,1101080013,"bale[1101080013][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101080014,153,[1101080014]KTB SA 475-0-99621-1 CA 475-6-00378-8 ระบบราง วช.59,1101080014,"bale[1101080014][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101080015,154,[1101080015]KTB SA 475-0-99620-3 CA 475-6-00376-1 สำปะหลัง วช.59,1101080015,"bale[1101080015][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101080016,155,[1101080016]KTB SA 475-3-00316-7 CA475-6-00402-4เคมีไฟฟ้าพกพา2,1101080016,"bale[1101080016][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101080017,156,[1101080017]KTB SA 475-3-00474-0 CA 475-6-00405-9 ประยุกต์ใช้,1101080017,"bale[1101080017][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101080018,157,[1101080018]BBL SA 080-0-09735-4 CA 080-3-00205-4 สวทช.-แผ่นกรองอากาศนาโน,1101080018,"bale[1101080018][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101080019,158,[1101080019]KTB SA 475-3-09637-8 CA 475-6-00420-2 จมูกอัจฉริยะ,1101080019,"bale[1101080019][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101080020,159,[1101080020]KTB SA 475-3-09671-8 CA 475-6-00422-9 เดนตีสแกน,1101080020,"bale[1101080020][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101080021,160,[1101080021]KTB SA 475-3-10409-5 CA 475-6-00436-9 พิพิธภัณฑ์,1101080021,"bale[1101080021][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101080022,161,[1101080022]KTB SA 475-3-10572-5 CA 475-6-00448-2สำปะหลัง วช60,1101080022,"bale[1101080022][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101080023,162,[1101080023]KTB SA 475-3-10571-7 CA 475-6-00447-4 ระบบราง วช60,1101080023,"bale[1101080023][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101080024,163,[1101080024]KTB SA 475-3-14306-6 CA 475-6-00464-4 ขนส่ง วช.59,1101080024,"bale[1101080024][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101080026,164,[1101080026]KTB SA 475-3-19382-9 CA 475-6-00481-4 ผลิตอนุภาคนา,1101080026,"bale[1101080026][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101080027,165,[1101080027]KTB SA 475-3-21562-8 CA 475-6-00537-3 การพัฒนา,1101080027,"bale[1101080027][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101090000,166,[1101090000]เงินฝากธนาคารที่มีวัตถุประสงค์เฉพาะ-แหล่งอื่น ๆ,1101090000,"bale[1101090000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101090001,167,[1101090001]BBL SA 080-0-07530-1 CA 080-3-00163-5 Tokyo tech,1101090001,"bale[1101090001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101090002,168,[1101090002]BBL SA 080-0-09540-8 CA 080-3-00198-1 มอเตอร์และระบบขับเคลื่อน,1101090002,"bale[1101090002][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101090003,169,[1101090003]BBL SA 080-0-12356-4 CA 080-3-00296-3 DAM SAFETY,1101090003,"bale[1101090003][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101090004,170,[1101090004]BBL SA 080-0-12383-8 CA 080-3-00302-9 NETPIE IOT,1101090004,"bale[1101090004][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101090005,171,[1101090005]BBL SA 080-0-12513-0 CA 080-3-00317-7 แบบจำลอง,1101090005,"bale[1101090005][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101090006,172,[1101090006]BBL SA 080-0-12839-9 CA 080-3-00327-6 เงินนอก ศอ.,1101090006,"bale[1101090006][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101090008,173,[1101090008]BBL SA 080-0-12908-2 CA 080-3-00329-2 สหสถาบัน,1101090008,"bale[1101090008][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101090009,174,[1101090009]BBL SA 080-0-12989-2 CA 080-3-00330-0 ค้นหายา,1101090009,"bale[1101090009][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101090010,175,[1101090010]BBL SA 080-0-12994-2 CA 080-3-00331-8 เก็บพลังงาน,1101090010,"bale[1101090010][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101090011,176,[1101090011]BBL SA 080-0-12999-1 CA 080-3-00332-6 SolarMove,1101090011,"bale[1101090011][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101090012,177,[1101090012]BBL SA 080-0-13000-7 CA 080-3-00333-4 Health,1101090012,"bale[1101090012][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101090013,178,[1101090013]BBL SA 080-0-13019-7 CA 080-3-00334-2 ผู้ประกอบการ,1101090013,"bale[1101090013][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101090015,179,[1101090015]BBL SA 080-0-13050-2 CA 080-3-00337-5 เพอรอฟสไกต์,1101090015,"bale[1101090015][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101090016,180,[1101090016]KTB SA 475-3-08320-9 CA 475-6-00417-2Energy-บริหาร,1101090016,"bale[1101090016][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101090017,181,[1101090017]KTB SA 475-3-08322-5 CA 475-6-00418-0Energyอุดหนุน,1101090017,"bale[1101090017][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101090018,182,[1101090018]KTB SA 475-3-09923-7 CA 475-6-00423-7 ไบโอดีเซล,1101090018,"bale[1101090018][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101090019,183,[1101090019]KTB SA 475-3-14305-8 CA 475-6-00463-6 กองทุนฯ,1101090019,"bale[1101090019][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101090020,184,[1101090020]KTB SA 475-3-20534-7 CA 475-6-00495-4 พัฒนาผงสี,1101090020,"bale[1101090020][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101090021,185,[1101090021]KTB SA 475-3-20533-9 CA 475-6-00494-6การใช้พลังงาน,1101090021,"bale[1101090021][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101090022,186,[1101090022]KTB SA 475-3-20876-1 CA 475-6-00509-8 เยื่อเลือก,1101090022,"bale[1101090022][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101090023,187,[1101090023]BBL SA 080-0-13061-9 CA 080-3-00339-1 พลังงานลม,1101090023,"bale[1101090023][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101090024,188,[1101090024]BBL SA 080-0-13064-3 CA 080-3-00340-9 อัตราค่าไฟฟ้า,1101090024,"bale[1101090024][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101090025,189,[1101090025]BBL SA 080-0-13121-1 CA 080-3-00342-5 One year project,1101090025,"bale[1101090025][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101090026,190,[1101090026]BBL SA 080-0-13126-0 CA 080-3-00344-1 มิวเทอร์ม-เฟสเซอซ์,1101090026,"bale[1101090026][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101090027,191,[1101090027]BBL SA 080-0-13136-9 CA 080-3-00345-8 รถโดยสารประจำทาง,1101090027,"bale[1101090027][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101090028,192,[1101090028]KTB SA 475-3-31857-5 CA 475-6-00579-9 เศรษฐกิจดิจิทัล,1101090028,"bale[1101090028][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101090029,193,[1101090029]KTB SA 475-3-31978-4 CA 475-6-00581-0 เศรษฐกิจดิจิทัล (MP-61-0006),1101090029,"bale[1101090029][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101090030,194,[1101090030]KTB SA 475-3-32354-4 CA 475-6-00599-3 สวทช.เงินนอกงบประมาณ,1101090030,"bale[1101090030][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101090031,195,[1101090031]BBL SA 080-0-13325-8 CA 080-3-00356-5 ทดสอบซอฟต์แวร์ ,1101090031,"bale[1101090031][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101090032,196,[1101090032]KTB SA 475-3-32462-1 CA 475-6-00600-0 เศรษฐกิจดิจิทัล (SP-62-0053),1101090032,"bale[1101090032][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101090033,197,[1101090033]KTB SA 475-3-32464-8 CA 475-6-00601-9 เศรษฐกิจดิจิทัล (SP-62-0054),1101090033,"bale[1101090033][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101090034,198,[1101090034]BBL SA 080-0-13350-6 CA 080-3-00358-1 อาหารฟังก์ชั่น,1101090034,"bale[1101090034][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101090035,199,[1101090035]KTB SA 475-3-42387-5 CA 475-6-00633-7 MalHivPOCTs,1101090035,"bale[1101090035][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101090036,200,[1101090036]KTB SA 475-3-42404-9 CA 475-6-00634-5 เซลล์ Vero และ MDCK,1101090036,"bale[1101090036][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101090037,201,[1101090037]KTB SA 475-3-42406-5 CA 475-6-00635-3 เพาะปลูกกัญชา,1101090037,"bale[1101090037][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1101099990,202,[1101099990]เงินฝากธนาคารที่มีวัตถุประสงค์เฉพาะ Interface,1101099990,"bale[1101099990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1102010000,203,[1102010000]ลูกหนี้การค้า,1102010000,"bale[1102010000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1102010001,204,[1102010001]ลูกหนี้การค้า - ในประเทศ หน่วยงานภาครัฐ,1102010001,"bale[1102010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1102010002,205,[1102010002]ลูกหนี้การค้า - ในประเทศ หน่วยงานเอกชน,1102010002,"bale[1102010002][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1102010003,206,[1102010003]ลูกหนี้การค้า - ต่างประเทศ,1102010003,"bale[1102010003][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1102010004,207,[1102010004]ลูกหนี้อยู่ระหว่างดำเนินคดี,1102010004,"bale[1102010004][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1102010005,208,[1102010005]ลูกหนี้ผ่อนชำระ,1102010005,"bale[1102010005][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1102010006,209,[1102010006]ลูกหนี้เงินให้กู้ระยะยาว - CD,1102010006,"bale[1102010006][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1102019990,210,[1102019990]ลูกหนี้การค้า - ในประเทศ หน่วยงานภาครัฐ Interface,1102019990,"bale[1102019990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1102019991,211,[1102019991]ลูกหนี้การค้า - ในประเทศ หน่วยงานเอกชน Interface,1102019991,"bale[1102019991][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1102019992,212,[1102019992]ลูกหนี้การค้า - ต่างประเทศ Interface,1102019992,"bale[1102019992][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1102019993,213,[1102019993]ลูกหนี้อยู่ระหว่างดำเนินคดี Interface,1102019993,"bale[1102019993][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1102019994,214,[1102019994]ลูกหนี้ผ่อนชำระ Interface,1102019994,"bale[1102019994][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1103010000,215,[1103010000]ค่าเผื่อหนี้สงสัยจะสูญ,1103010000,"bale[1103010000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1103010001,216,[1103010001]ค่าเผื่อหนี้สงสัยจะสูญ,1103010001,"bale[1103010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1103019990,217,[1103019990]ค่าเผื่อหนี้สงสัยจะสูญ Interface,1103019990,"bale[1103019990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1104010000,218,[1104010000]เงินยืมทดรองจ่ายให้พนักงาน,1104010000,"bale[1104010000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1104010001,219,[1104010001]เงินยืมทดรองจ่าย,1104010001,"bale[1104010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1104019990,220,[1104019990]เงินยืมทดรองจ่าย Interface,1104019990,"bale[1104019990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1105010000,221,[1105010000]วัสดุคงเหลือ,1105010000,"bale[1105010000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1105010001,222,[1105010001]วัสดุสำนักงาน,1105010001,"bale[1105010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1105010002,223,[1105010002]วัสดุโฆษณาและเผยแพร่,1105010002,"bale[1105010002][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1105010003,224,[1105010003]วัสดุงานบ้านและงานครัว,1105010003,"bale[1105010003][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1105010004,225,[1105010004]วัสดุหนังสือ วารสาร และตำรา,1105010004,"bale[1105010004][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1105010005,226,[1105010005]วัสดุวิทยาศาสตร์,1105010005,"bale[1105010005][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1105010006,227,[1105010006]วัสดุคอมพิวเตอร์,1105010006,"bale[1105010006][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1105010007,228,[1105010007]วัสดุไฟฟ้าและวิทยุ,1105010007,"bale[1105010007][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1105010008,229,[1105010008]วัสดุอุปกรณ์ทางการแพทย์,1105010008,"bale[1105010008][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1105010009,230,[1105010009]วัสดุกีฬา/ดนตรีนาฎศิลป์,1105010009,"bale[1105010009][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1105010010,231,[1105010010]วัสดุงานวิจัยต้นแบบ,1105010010,"bale[1105010010][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1105010011,232,[1105010011]พักโอนเข้าวัสดุคงเหลือจากการ Settlement I/O,1105010011,"bale[1105010011][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1105019990,233,[1105019990]วัสดุคงเหลือ-Interface,1105019990,"bale[1105019990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1106010000,234,[1106010000]ค่าใช้จ่ายล่วงหน้า,1106010000,"bale[1106010000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1106010001,235,[1106010001]ค่าเช่าจ่ายล่วงหน้า,1106010001,"bale[1106010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1106010002,236,[1106010002]ค่าประกันภัยจ่ายล่วงหน้า,1106010002,"bale[1106010002][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1106019991,237,[1106019991]ค่าประกันจ่ายล่วงหน้า Interface,1106019991,"bale[1106019991][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1106010003,238,[1106010003]ค่าสมาชิก หนังสือและวารสารจ่ายล่วงหน้า,1106010003,"bale[1106010003][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1106019992,239,[1106019992]ค่าสมาชิก/หนังสือและวารสารจ่ายล่วงหน้า Interface,1106019992,"bale[1106019992][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1106010004,240,[1106010004]ค่าลิขสิทธ์จ่ายล่วงหน้า,1106010004,"bale[1106010004][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1106019993,241,[1106019993]ค่าลิขสิทธ์จ่ายล่วงหน้า Interface,1106019993,"bale[1106019993][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1106010005,242,[1106010005]ค่า AUC จ่ายล่วงหน้า,1106010005,"bale[1106010005][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1106010006,243,[1106010006]ค่า AIT จ่ายล่วงหน้า,1106010006,"bale[1106010006][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1106019995,244,[1106019995]ค่า AIT จ่ายล่วงหน้า Interface,1106019995,"bale[1106019995][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1106019994,245,[1106019994]ค่า AUC จ่ายล่วงหน้า Interface,1106019994,"bale[1106019994][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1106010007,246,[1106010007]ค่าใช้จ่ายจ่ายล่วงหน้าอื่น,1106010007,"bale[1106010007][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1106019996,247,[1106019996]ค่าใช้จ่ายจ่ายล่วงหน้าอื่น Interface,1106019996,"bale[1106019996][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1106010008,248,[1106010008]เงินจ่ายล่วงหน้าอื่น,1106010008,"bale[1106010008][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1106019997,249,[1106019997]เงินจ่ายล่วงหน้าอื่น Interface,1106019997,"bale[1106019997][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1106019990,250,[1106019990]ค่าเช่าจ่ายล่วงหน้า Interface,1106019990,"bale[1106019990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1107010000,251,[1107010000]เงินอุดหนุนจากงบประมาณแผ่นดินค้างรับ,1107010000,"bale[1107010000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1107010001,252,[1107010001]เงินอุดหนุนจากงบประมาณแผ่นดินค้างรับ-อุดหนุนเฉพาะกิจ,1107010001,"bale[1107010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1107010090,253,[1107010090]เงินอุดหนุนจากงบประมาณแผ่นดินค้างรับ Interface,1107010090,"bale[1107010090][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1107010002,254,[1107010002]เงินอุดหนุนจากงบประมาณแผ่นดินค้างรับ-อุดหนุนทั่วไป,1107010002,"bale[1107010002][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1108010000,255,[1108010000]ดอกเบี้ยค้างรับ,1108010000,"bale[1108010000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1108010001,256,[1108010001]ดอกเบี้ยค้างรับ,1108010001,"bale[1108010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1108010090,257,[1108010090]ดอกเบี้ยค้างรับ Interface,1108010090,"bale[1108010090][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1109010000,258,[1109010000]ภาษีมูลค่าเพิ่ม,1109010000,"bale[1109010000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1109010001,259,[1109010001]ภาษีซื้อ,1109010001,"bale[1109010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1109010002,260,[1109010002]ภาษีมูลค่าเพิ่ม,1109010002,"bale[1109010002][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1109010003,261,[1109010003]พักภาษีซื้อ,1109010003,"bale[1109010003][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1109010090,262,[1109010090]พักภาษีซื้อ Interface,1109010090,"bale[1109010090][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1190000000,263,[1190000000]สินทรัพย์หมุนเวียนอื่น,1190000000,"bale[1190000000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1190010000,264,[1190010000]ลูกหนี้อื่น,1190010000,"bale[1190010000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1190010001,265,[1190010001]ลูกหนี้หน่วยบริการ,1190010001,"bale[1190010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1190019990,266,[1190019990]ลูกหนี้หน่วยบริการ Interface,1190019990,"bale[1190019990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1190010002,267,[1190010002]เงินรอรับรู้ - ส/ท,1190010002,"bale[1190010002][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1190019900,268,[1190019900]ลูกหนี้อื่น,1190019900,"bale[1190019900][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1190019991,269,[1190019991]ลูกหนี้อื่น ๆ Interface,1190019991,"bale[1190019991][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1190900000,270,[1190900000]สินทรัพย์หมุนเวียนอื่น,1190900000,"bale[1190900000][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1190909900,271,[1190909900]สินทรัพย์หมุนเวียนอื่น,1190909900,"bale[1190909900][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1200000000,272,[1200000000]สินทรัพย์ไม่หมุนเวียน,1200000000,"bale[1200000000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1201000000,273,[1201000000]เงินฝากธนาคารประจำ มากกว่า 3 เดือน,1201000000,"bale[1201000000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1201010000,274,[1201010000]เงินฝากธนาคาร-ประจำ มากกว่า 3-12 เดือน,1201010000,"bale[1201010000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1201010001,275,[1201010001]BBL FA 942-6-00007-2 สวทช.[12 เดือน],1201010001,"bale[1201010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1201010002,276,[1201010002]BBL FA 080-2-01142-9 [4 เดือน],1201010002,"bale[1201010002][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1201010003,277,[1201010003]BBL FA 080-2-01363-1 (10 เดือน),1201010003,"bale[1201010003][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1201010004,278,[1201010004]TNC FA 482-1-10949-7 (6 เดือน),1201010004,"bale[1201010004][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1201010005,279,[1201010005]เงินโอนระหว่างธนาคาร,1201010005,"bale[1201010005][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1201019990,280,[1201019990]เงินฝากธนาคาร-ประจำ มากกว่า 3-12 เดือน Interface,1201019990,"bale[1201019990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1201020000,281,[1201020000]เงินฝากธนาคาร-ประจำเกิน 1 ปี,1201020000,"bale[1201020000][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1201029990,282,[1201029990]เงินฝากธนาคาร-ประจำเกิน 1 ปี ธนาคารรัฐ Interface,1201029990,"bale[1201029990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1202000000,283,[1202000000]เงินให้กู้ระยะยาว,1202000000,"bale[1202000000][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1202019900,284,[1202019900]เงินให้กู้ระยะยาวอื่น,1202019900,"bale[1202019900][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1203000000,285,[1203000000]เงินลงทุนระยะยาว,1203000000,"bale[1203000000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1203010000,286,[1203010000]เงินลงทุนในบริษัท จำกัด สุทธิ,1203010000,"bale[1203010000][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1203010001,287,[1203010001]เงินลงทุนในบริษัทจำกัด,1203010001,"bale[1203010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1203010002,288,[1203010002]ปรับมูลค่าเงินลงทุนในบริษัทจำกัด,1203010002,"bale[1203010002][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1203010003,289,[1203010003]ค่าเผื่อการด้อยค่า-เงินลงทุนในบริษัทจำกัด,1203010003,"bale[1203010003][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1203900000,290,[1203900000]เงินลงทุนระยะยาวอื่น,1203900000,"bale[1203900000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1203900001,291,[1203900001]เงินลงทุนระยะยาว,1203900001,"bale[1203900001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1203900002,292,[1203900002]ปรับมูลค่าเงินลงทุนระยะยาว,1203900002,"bale[1203900002][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1203900003,293,[1203900003]ค่าเผื่อการด้อยค่า-เงินลงทุนระยะยาว,1203900003,"bale[1203900003][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1203909990,294,[1203909990]ค่าเผื่อการด้อยค่า-เงินลงทุนระยะยาว Interface,1203909990,"bale[1203909990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1203900004,295,[1203900004]เงินลงทุนเผื่อขาย,1203900004,"bale[1203900004][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1203909991,296,[1203909991]เงินลงทุนเผื่อขาย Interface,1203909991,"bale[1203909991][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1204000000,297,[1204000000]เงินร่วมลงทุน,1204000000,"bale[1204000000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1204010001,298,[1204010001]เงินลงทุนหน่วยบริการ,1204010001,"bale[1204010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1204019990,299,[1204019990]เงินลงทุนหน่วยบริการ Interface,1204019990,"bale[1204019990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1205000000,300,[1205000000]เงินค้ำประกันจ่าย,1205000000,"bale[1205000000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1205010001,301,[1205010001]เงินค้ำประกันสัญญา,1205010001,"bale[1205010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1205010002,302,[1205010002]เงินค้ำประกันผลงาน,1205010002,"bale[1205010002][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1205019990,303,[1205019990]เงินค้ำประกันสัญญา Interface,1205019990,"bale[1205019990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1205019991,304,[1205019991]เงินค้ำประกันผลงาน Interface,1205019991,"bale[1205019991][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1206000000,305,[1206000000]เงินมัดจำ,1206000000,"bale[1206000000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1206010001,306,[1206010001]เงินมัดจำ-ค่าเช่าอาคาร ค่าบริการ,1206010001,"bale[1206010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1206010002,307,[1206010002]เงินมัดจำ-ค่าโทรศัพท์,1206010002,"bale[1206010002][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1206010003,308,[1206010003]เงินมัดจำ-อื่น,1206010003,"bale[1206010003][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1206019990,309,[1206019990]เงินมัดจำ-ค่าเช่าอาคาร/ค่าบริการ Interface,1206019990,"bale[1206019990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1206019991,310,[1206019991]เงินมัดจำ-ค่าโทรศัพท์ Interface,1206019991,"bale[1206019991][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1206019992,311,[1206019992]เงินมัดจำ-อื่น Interface,1206019992,"bale[1206019992][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1207000000,312,[1207000000]อสังหาริมทรัยพ์เพื่อการลงทุน,1207000000,"bale[1207000000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1207010000,313,[1207010000]อาคาร/ส่วนปรับปรุงอาคารเพื่อการลงทุน,1207010000,"bale[1207010000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1207010001,314,[1207010001]อาคารเพื่อการลงทุน,1207010001,"bale[1207010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1207010002,315,[1207010002]ส่วนปรับปรุงอาคารเพื่อการลงทุน,1207010002,"bale[1207010002][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1207019990,316,[1207019990]อาคารเพื่อการลงทุน Interface,1207019990,"bale[1207019990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1207019991,317,[1207019991]ส่วนปรับปรุงอาคารเพื่อการลงทุน Interface,1207019991,"bale[1207019991][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1208000000,318,[1208000000]ที่ดิน อาคารและครุภัณฑ์,1208000000,"bale[1208000000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1208010000,319,[1208010000]ที่ดิน/ส่วนปรับปรุงที่ดิน,1208010000,"bale[1208010000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1208010001,320,[1208010001]ที่ดิน,1208010001,"bale[1208010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1208010002,321,[1208010002]ส่วนปรับปรุงที่ดิน,1208010002,"bale[1208010002][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1208019990,322,[1208019990]ที่ดิน Interface,1208019990,"bale[1208019990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1208019991,323,[1208019991]ส่วนปรับปรุงที่ดิน Interface,1208019991,"bale[1208019991][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1208020000,324,[1208020000]อาคาร/ส่วนปรับปรุอาคาร,1208020000,"bale[1208020000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1208020001,325,[1208020001]อาคาร,1208020001,"bale[1208020001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1208020002,326,[1208020002]อาคารชั่วคราว,1208020002,"bale[1208020002][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1208020003,327,[1208020003]สิ่งปลูกสร้าง,1208020003,"bale[1208020003][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1208020004,328,[1208020004]ส่วนปรับปรุงอาคาร,1208020004,"bale[1208020004][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1208029990,329,[1208029990]อาคาร Interface,1208029990,"bale[1208029990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1208029991,330,[1208029991]อาคารชั่วคราว Interface,1208029991,"bale[1208029991][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1208029992,331,[1208029992]สิ่งปลูกสร้าง Interface,1208029992,"bale[1208029992][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1208029993,332,[1208029993]ส่วนปรับปรุงอาคาร Interface,1208029993,"bale[1208029993][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1208030000,333,[1208030000]ครุภัณฑ์,1208030000,"bale[1208030000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1208030001,334,[1208030001]ครุภัณฑ์และอุปกรณ์สำนักงาน,1208030001,"bale[1208030001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1208030002,335,[1208030002]ครุภัณฑ์และอุปกรณ์วิทยาศาสตร์,1208030002,"bale[1208030002][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1208030003,336,[1208030003]ครุภัณฑ์และอุปกรณ์โฆษณาและเผยแพร่,1208030003,"bale[1208030003][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1208030004,337,[1208030004]ครุภัณฑ์และอุปกรณ์ไฟฟ้าและวิทยุ,1208030004,"bale[1208030004][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1208030005,338,[1208030005]ครุภัณฑ์และอุปกรณ์คอมพิวเตอร์,1208030005,"bale[1208030005][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1208030006,339,[1208030006]ครุภัณฑ์และอุปกรณ์งานบ้านงานครัว,1208030006,"bale[1208030006][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1208030007,340,[1208030007]ครุภัณฑ์และอุปกรณ์การแพทย์,1208030007,"bale[1208030007][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1208030008,341,[1208030008]ครุภัณฑ์และอุปกรณ์การเกษตร,1208030008,"bale[1208030008][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1208030009,342,[1208030009]ครุภัณฑ์และอุปกรณ์กีฬา/ดนตรีนาฏศิลป์,1208030009,"bale[1208030009][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1208030010,343,[1208030010]ครุภัณฑ์และอุปกรณ์ก่อสร้าง,1208030010,"bale[1208030010][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1208039990,344,[1208039990]ครุภัณฑ์และอุปกรณ์สำนักงาน Interface,1208039990,"bale[1208039990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1208039991,345,[1208039991]ครุภัณฑ์และอุปกรณ์วิทยาศาสตร์ Interface,1208039991,"bale[1208039991][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1208039992,346,[1208039992]ครุภัณฑ์และอุปกรณ์โฆษณาและเผยแพร่ Interface,1208039992,"bale[1208039992][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1208039993,347,[1208039993]ครุภัณฑ์และอุปกรณ์ไฟฟ้าและวิทยุ Interface,1208039993,"bale[1208039993][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1208039994,348,[1208039994]ครุภัณฑ์และอุปกรณ์คอมพิวเตอร์ Interface,1208039994,"bale[1208039994][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1208039995,349,[1208039995]ครุภัณฑ์และอุปกรณ์งานบ้านงานครัว Interface,1208039995,"bale[1208039995][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1208039996,350,[1208039996]ครุภัณฑ์และอุปกรณ์การแพทย์ Interface,1208039996,"bale[1208039996][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1208039997,351,[1208039997]ครุภัณฑ์และอุปกรณ์การเกษตร Interface,1208039997,"bale[1208039997][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1208039998,352,[1208039998]ครุภัณฑ์และอุปกรณ์กีฬา/ดนตรีนาฏศิลป์ Interface,1208039998,"bale[1208039998][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1208039999,353,[1208039999]ครุภัณฑ์และอุปกรณ์ก่อสร้าง Interface,1208039999,"bale[1208039999][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1209000000,354,[1209000000]ยานพาหนะ,1209000000,"bale[1209000000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1209010000,355,[1209010000]ยานพาหนะ,1209010000,"bale[1209010000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1209010001,356,[1209010001]ยานพาหนะ,1209010001,"bale[1209010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1209019990,357,[1209019990]ยานพาหนะ-Interface,1209019990,"bale[1209019990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1210000000,358,[1210000000]สินทรัพย์ไม่มีตัวตน,1210000000,"bale[1210000000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1210010000,359,[1210010000]สินทรัพย์ไม่มีตัวตน,1210010000,"bale[1210010000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1210010001,360,[1210010001]สินทรัพย์ไม่มีตัวตน,1210010001,"bale[1210010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1210019990,361,[1210019990]สินทรัพย์ไม่มีตัวตน Interface,1210019990,"bale[1210019990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1211000000,362,[1211000000]สินทรัพย์ตามสัญญาเช่าการเงิน,1211000000,"bale[1211000000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1211010000,363,[1211010000]สินทรัพย์ตามสัญญาเช่าการเงิน,1211010000,"bale[1211010000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1211010001,364,[1211010001]สินทรัพย์ตามสัญญาเช่าการเงิน,1211010001,"bale[1211010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1211019990,365,[1211019990]สินทรัพย์ตามสัญญาเช่าการเงิน Interface,1211019990,"bale[1211019990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212000000,366,[1212000000]ค่าเสื่อมราคาสะสม,1212000000,"bale[1212000000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212010000,367,[1212010000]ค่าเสื่อมสะสม-อาคาร/ส่วนปรับปรุงอาคารเพื่อการลงทุน,1212010000,"bale[1212010000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212010001,368,[1212010001]ค่าเสื่อมสะสม-อาคารเพื่อการลงทุน,1212010001,"bale[1212010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212010002,369,[1212010002]ค่าเสื่อมสะสม-ส่วนปรับปรุงอาคารเพื่อการลงทุน,1212010002,"bale[1212010002][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212019990,370,[1212019990]ค่าเสื่อมสะสม-อาคารเพื่อการลงทุน Interface,1212019990,"bale[1212019990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212019991,371,[1212019991]ค่าเสื่อมสะสม-ส่วนปรับปรุงอาคารเพื่อการลงทุน Interface,1212019991,"bale[1212019991][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212020000,372,[1212020000]ค่าเสื่อมสะสม-ส่วนปรับปรุงที่ดิน,1212020000,"bale[1212020000][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212020001,373,[1212020001]ค่าเสื่อมสะสม-ส่วนปรับปรุงที่ดิน,1212020001,"bale[1212020001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212029990,374,[1212029990]ค่าเสื่อมสะสม-ส่วนปรับปรุงที่ดิน Interface,1212029990,"bale[1212029990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212030000,375,[1212030000]ค่าเสื่อมสะสม-อาคาร/ส่วนปรับปรุงอาคาร,1212030000,"bale[1212030000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212030001,376,[1212030001]ค่าเสื่อมสะสม-อาคาร,1212030001,"bale[1212030001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212030002,377,[1212030002]ค่าเสื่อมสะสม-อาคารชั่วคราว,1212030002,"bale[1212030002][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212030003,378,[1212030003]ค่าเสื่อมสะสม-สิ่งปลูกสร้าง,1212030003,"bale[1212030003][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212030004,379,[1212030004]ค่าเสื่อมสะสม-ส่วนปรับปรุงอาคาร,1212030004,"bale[1212030004][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212039990,380,[1212039990]ค่าเสื่อมสะสม-อาคาร Interface,1212039990,"bale[1212039990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212039991,381,[1212039991]ค่าเสื่อมสะสม-อาคารชั่วคราว Interface,1212039991,"bale[1212039991][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212039992,382,[1212039992]ค่าเสื่อมสะสม-สิ่งปลูกสร้าง Interface,1212039992,"bale[1212039992][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212039993,383,[1212039993]ค่าเสื่อมสะสม-ส่วนปรับปรุงอาคาร Interface,1212039993,"bale[1212039993][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212040000,384,[1212040000]ค่าเสื่อมสะสม-ครุภัณฑ์,1212040000,"bale[1212040000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212040001,385,[1212040001]ค่าเสื่อมสะสม-ครุภัณฑ์สำนักงาน,1212040001,"bale[1212040001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212040002,386,[1212040002]ค่าเสื่อมสะสม-ครุภัณฑ์วิทยาศาสตร์,1212040002,"bale[1212040002][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212040003,387,[1212040003]ค่าเสื่อมสะสม-ครุภัณฑ์โฆษณาและเผยแพร่,1212040003,"bale[1212040003][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212040004,388,[1212040004]ค่าเสื่อมสะสม-ครุภัณฑ์ไฟฟ้าและวิทยุ,1212040004,"bale[1212040004][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212040005,389,[1212040005]ค่าเสื่อมสะสม-ครุภัณฑ์คอมพิวเตอร์,1212040005,"bale[1212040005][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212040006,390,[1212040006]ค่าเสื่อมสะสม-ครุภัณฑ์งานบ้านงานครัว,1212040006,"bale[1212040006][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212040007,391,[1212040007]ค่าเสื่อมสะสม-ครุภัณฑ์การแพทย์,1212040007,"bale[1212040007][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212040008,392,[1212040008]ค่าเสื่อมสะสม-ครุภัณฑ์การเกษตร,1212040008,"bale[1212040008][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212040009,393,[1212040009]ค่าเสื่อมสะสม-ครุภัณฑ์กีฬา/ดนตรี-นาฏศิลป์,1212040009,"bale[1212040009][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212040010,394,[1212040010]ค่าเสื่อมสะสม-ครุภัณฑ์และอุปกรณ์ก่อสร้าง,1212040010,"bale[1212040010][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212049990,395,[1212049990]ค่าเสื่อมสะสม-ครุภัณฑ์สำนักงาน Interface,1212049990,"bale[1212049990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212049991,396,[1212049991]ค่าเสื่อมสะสม-ครุภัณฑ์วิทยาศาสตร์ Interface,1212049991,"bale[1212049991][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212049992,397,[1212049992]ค่าเสื่อมสะสม-ครุภัณฑ์โฆษณาและเผยแพร่ Interface,1212049992,"bale[1212049992][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212049993,398,[1212049993]ค่าเสื่อมสะสม-ครุภัณฑ์ไฟฟ้าและวิทยุ Interface,1212049993,"bale[1212049993][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212049994,399,[1212049994]ค่าเสื่อมสะสม-ครุภัณฑ์คอมพิวเตอร์ Interface,1212049994,"bale[1212049994][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212049995,400,[1212049995]ค่าเสื่อมสะสม-ครุภัณฑ์งานบ้านงานครัว Interface,1212049995,"bale[1212049995][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212049996,401,[1212049996]ค่าเสื่อมสะสม-ครุภัณฑ์การแพทย์ Interface,1212049996,"bale[1212049996][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212049997,402,[1212049997]ค่าเสื่อมสะสม-ครุภัณฑ์การเกษตร Interface,1212049997,"bale[1212049997][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212049998,403,[1212049998]ค่าเสื่อมสะสม-ครุภัณฑ์กีฬา/ดนตรี-นาฏศิลป์ Interface,1212049998,"bale[1212049998][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212049999,404,[1212049999]ค่าเสื่อมสะสม-ครุภัณฑ์และอุปกรณ์ก่อสร้าง Interface,1212049999,"bale[1212049999][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212050000,405,[1212050000]ค่าเสื่อมสะสม-ยานพาหนะ,1212050000,"bale[1212050000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212050001,406,[1212050001]ค่าเสื่อมสะสม-ยานพาหนะ,1212050001,"bale[1212050001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212059990,407,[1212059990]ค่าเสื่อมสะสม-ยานพาหนะ Interface,1212059990,"bale[1212059990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212060000,408,[1212060000]ค่าตัดจำหน่ายสะสม-สินทรัพย์ไม่มีตัวตน,1212060000,"bale[1212060000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212060001,409,[1212060001]ค่าตัดจำหน่ายสะสม-สินทรัพย์ไม่มีตัวตน,1212060001,"bale[1212060001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212069990,410,[1212069990]ค่าตัดจำหน่ายสะสม-สินทรัพย์ไม่มีตัวตน Interface,1212069990,"bale[1212069990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212070000,411,[1212070000]ค่าเสื่อมราคาสะสม-สินทรัพย์ตามสัญญาเช่าการเงิน,1212070000,"bale[1212070000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1212070001,412,[1212070001]ค่าเสื่อมราคาสะสม-สินทรัพย์ตามสัญญาเช่าการเงิน,1212070001,"bale[1212070001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1213000000,413,[1213000000]สินทรัพย์ระหว่างก่อสร้าง,1213000000,"bale[1213000000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1213010001,414,[1213010001]สินทรัพย์ระหว่างก่อสร้าง-อาคาร,1213010001,"bale[1213010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1213010002,415,[1213010002]สินทรัพย์ระหว่างก่อสร้าง-ค่าควบคุมงาน,1213010002,"bale[1213010002][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1213010003,416,[1213010003]สินทรัพย์ระหว่างก่อสร้าง-ค่าออกแบบอาคาร,1213010003,"bale[1213010003][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1213010004,417,[1213010004]สินทรัพย์ระหว่างก่อสร้าง-ครุภัณฑ์อื่นๆ,1213010004,"bale[1213010004][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1213019990,418,[1213019990]สินทรัพย์ระหว่างก่อสร้าง-อาคาร Interface,1213019990,"bale[1213019990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1213019991,419,[1213019991]สินทรัพย์ระหว่างก่อสร้าง-ค่าควบคุมงาน Interface,1213019991,"bale[1213019991][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1213019992,420,[1213019992]สินทรัพย์ระหว่างก่อสร้าง-ค่าออกแบบอาคาร Interface,1213019992,"bale[1213019992][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1213019993,421,[1213019993]สินทรัพย์ระหว่างก่อสร้าง-ติดตั้งเครื่องจักร Interface,1213019993,"bale[1213019993][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1214000000,422,[1214000000]สินทรัพย์ระหว่างทาง,1214000000,"bale[1214000000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1214010001,423,[1214010001]สินทรัพย์ระหว่างทาง,1214010001,"bale[1214010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1214010002,424,[1214010002]พักครุภัณฑ์,1214010002,"bale[1214010002][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1214010003,425,[1214010003]Down payment พักครุภัณฑ์,1214010003,"bale[1214010003][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1214010004,426,[1214010004]Clearing down payment พักครุภัณฑ์,1214010004,"bale[1214010004][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1214010005,427,[1214010005]ค่าเสื่อมสะสม-พักครุภัณฑ์,1214010005,"bale[1214010005][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1214019990,428,[1214019990]สินทรัพย์ระหว่างทาง-INTERFACE,1214019990,"bale[1214019990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1290000000,429,[1290000000]สินทรัพย์ไม่หมุนเวียนอื่น,1290000000,"bale[1290000000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1290010001,430,[1290010001]เงินกู้ยืมพนักงานผู้ประสบภัยธรรมชาติ,1290010001,"bale[1290010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1290010002,431,[1290010002]ลูกหนี้ระหว่างบังคับคดี,1290010002,"bale[1290010002][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1290010003,432,[1290010003]ดอกเบี้ยจ่ายรอการรับรู้,1290010003,"bale[1290010003][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1290019990,433,[1290019990]ลูกหนี้ระหว่างรอบังคับคดี Interface,1290019990,"bale[1290019990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th1290019900,434,[1290019900]สินทรัพย์ไม่หมุนเวียนอื่น,1290019900,"bale[1290019900][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2000000000,435,[2000000000]หนี้สิน,2000000000,"bale[2000000000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2100000000,436,[2100000000]หนี้สินหมุนเวียน,2100000000,"bale[2100000000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2101010000,437,[2101010000]เจ้าหนี้การค้า,2101010000,"bale[2101010000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2101010001,438,[2101010001]เจ้าหนี้การค้า - ในประเทศ,2101010001,"bale[2101010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2101010002,439,[2101010002]เจ้าหนี้การค้า - ต่างประเทศ,2101010002,"bale[2101010002][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2101010003,440,[2101010003]GR-IR (เจ้าหนี้การค้า),2101010003,"bale[2101010003][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2101010004,441,[2101010004]เจ้าหนี้ฝากขายหนังสือ (Consignment),2101010004,"bale[2101010004][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2101019990,442,[2101019990]เจ้าหนี้การค้า-ในประเทศ Interface,2101019990,"bale[2101019990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2101019991,443,[2101019991]เจ้าหนี้การค้า-ต่างประเทศ Interface,2101019991,"bale[2101019991][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2102010000,444,[2102010000]เจ้าหนี้อื่น,2102010000,"bale[2102010000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2102010001,445,[2102010001]เจ้าหนี้หน่วยบริการ,2102010001,"bale[2102010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2102019992,446,[2102019992]เจ้าหนี้อื่น Interface,2102019992,"bale[2102019992][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2102010002,447,[2102010002]เงินรอรับรู้,2102010002,"bale[2102010002][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2102019991,448,[2102019991]เงินรอรับรู้ Interface,2102019991,"bale[2102019991][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2102019900,449,[2102019900]เจ้าหนี้อื่น,2102019900,"bale[2102019900][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2102019990,450,[2102019990]เจ้าหนี้หน่วยบริการ Interface,2102019990,"bale[2102019990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2103010000,451,[2103010000]ค่าใช้จ่ายค้างจ่าย,2103010000,"bale[2103010000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2103010001,452,[2103010001]ค่าใช้จ่ายค้างจ่าย,2103010001,"bale[2103010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2103019990,453,[2103019990]ค่าใช้จ่ายค้างจ่าย Interface,2103019990,"bale[2103019990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2104010000,454,[2104010000]รายได้รับล่วงหน้า,2104010000,"bale[2104010000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2104010001,455,[2104010001]รายได้รับล่วงหน้า,2104010001,"bale[2104010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2104019990,456,[2104019990]รายได้รับล่วงหน้า Interface,2104019990,"bale[2104019990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2105010000,457,[2105010000]เงินค้างนำส่ง,2105010000,"bale[2105010000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2105010001,458,[2105010001]เงินกองทุนสำรองเลี้ยงชีพ,2105010001,"bale[2105010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2105010002,459,[2105010002]ภาษีเงินได้บุคคลธรรมดาหัก ณ ที่จ่าย,2105010002,"bale[2105010002][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2105010003,460,[2105010003]ภาษีเงินได้นิติบุคคลหัก ณ ที่จ่าย,2105010003,"bale[2105010003][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2106010000,461,[2106010000]ภาษีขาย,2106010000,"bale[2106010000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2106010001,462,[2106010001]ภาษีขาย,2106010001,"bale[2106010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2106010002,463,[2106010002]พักภาษีขาย,2106010002,"bale[2106010002][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2106019990,464,[2106019990]พักภาษีขาย Interface,2106019990,"bale[2106019990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2107010000,465,[2107010000]เงินงบประมาณกันเบิกเหลื่อมปี,2107010000,"bale[2107010000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2107010001,466,[2107010001]เงินงบประมาณกันเบิกเหลื่อมปี,2107010001,"bale[2107010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2107019990,467,[2107019990]เงินงบประมาณกันเบิกเหลื่อมปี Interface,2107019990,"bale[2107019990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2190010000,468,[2190010000]หนี้สินหมุนเวียนอื่น,2190010000,"bale[2190010000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2190010001,469,[2190010001]รายได้รอการรับรู้,2190010001,"bale[2190010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2190019990,470,[2190019990]รายได้รอการรับรู้ Interface,2190019990,"bale[2190019990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2190019900,471,[2190019900]หนี้สินหมุนเวียนอื่น,2190019900,"bale[2190019900][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2200000000,472,[2200000000]หนี้สินไม่หมุนเวียน,2200000000,"bale[2200000000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2201010000,473,[2201010000]เงินสำรองรอจ่าย,2201010000,"bale[2201010000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2201010001,474,[2201010001]เงินบำเหน็จพนักงาน สวทช. รอจ่าย,2201010001,"bale[2201010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2201019990,475,[2201019990]เงินบำเหน็จพนักงาน สวทช. รอจ่าย Interface,2201019990,"bale[2201019990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2201010002,476,[2201010002]เงินค่าสมนาคุณ สวทช. รอจ่าย,2201010002,"bale[2201010002][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2201019991,477,[2201019991]เงินค่าสมนาคุณ สวทช. รอจ่าย Interface,2201019991,"bale[2201019991][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2202010000,478,[2202010000]หนี้สินตามสัญญาเช่าการเงิน,2202010000,"bale[2202010000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2202010001,479,[2202010001]หนี้สินตามสัญญาเช่าการเงิน,2202010001,"bale[2202010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2202019990,480,[2202019990]หนี้สินตามสัญญาเช่าการเงิน Interface,2202019990,"bale[2202019990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2203010000,481,[2203010000]เงินมัดจำ/เงินค้ำประกัน,2203010000,"bale[2203010000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2203010001,482,[2203010001]เงินมัดจำรับ-ค่าเช่าสำนักงาน,2203010001,"bale[2203010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2203019990,483,[2203019990]เงินมัดจำรับ-ค่าเช่าสำนักงาน Interface,2203019990,"bale[2203019990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2203010002,484,[2203010002]เงินมัดจำรับ-ค่าบริการส่วนกลาง,2203010002,"bale[2203010002][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2203019991,485,[2203019991]เงินมัดจำรับ-ค่าบริการส่วนกลาง Interface,2203019991,"bale[2203019991][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2203010003,486,[2203010003]เงินมัดจำรับ-ค่าตกแต่งพื้นที่,2203010003,"bale[2203010003][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2203010004,487,[2203010004]เงินมัดจำรับ-ค่าเช่าป้าย,2203010004,"bale[2203010004][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2203019993,488,[2203019993]เงินมัดจำรับ-ค่าเช่าป้าย Interface,2203019993,"bale[2203019993][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2203010005,489,[2203010005]เงินมัดจำรับ-อื่น,2203010005,"bale[2203010005][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2203019994,490,[2203019994]เงินมัดจำรับ-อื่น Interface,2203019994,"bale[2203019994][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2203010006,491,[2203010006]เงินค้ำประกันรับ-สัญญา,2203010006,"bale[2203010006][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2203010007,492,[2203010007]เงินค้ำประกันรับ-ผลงาน,2203010007,"bale[2203010007][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2203010008,493,[2203010008]เงินค้ำประกันรับอื่น,2203010008,"bale[2203010008][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2203019992,494,[2203019992]เงินมัดจำรับ-ค่าตกแต่งพื้นที่ Interface,2203019992,"bale[2203019992][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2203019995,495,[2203019995]เงินค้ำประกันรับ-สัญญา Interface,2203019995,"bale[2203019995][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2203019996,496,[2203019996]เงินค้ำประกันรับ-ผลงาน Interface,2203019996,"bale[2203019996][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2203019997,497,[2203019997]เงินค้ำประกันรับอื่น Interface,2203019997,"bale[2203019997][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2204010000,498,[2204010000]รายได้เงินอุดหนุนรอการรับรู้,2204010000,"bale[2204010000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2204010100,499,[2204010100]รายได้รอการรับรู้ - รอบังคับคดี,2204010100,"bale[2204010100][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2204019990,500,[2204019990]รายได้รอการรับรู้ - รอบังคับคดี Interface,2204019990,"bale[2204019990][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2290010000,501,[2290010000]หนี้สินไม่หมุนเวียนอื่น,2290010000,"bale[2290010000][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th2290019900,502,[2290019900]หนี้สินไม่หมุนเวียนอื่น,2290019900,"bale[2290019900][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th3000000000,503,[3000000000]เงินกองทุน (ส่วนของเจ้าของ),3000000000,"bale[3000000000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th3101010000,504,[3101010000]ทุน,3101010000,"bale[3101010000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th3101010001,505,[3101010001]ทุนประเดิมของ สวทช.,3101010001,"bale[3101010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th3101010002,506,[3101010002]ทุนรับโอน-โครงการวิทยาศาสตร์และเทคโนโลยีฯ (STDB),3101010002,"bale[3101010002][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th3101010003,507,[3101010003]ทุนรับโอน-สำนักงานปลัดกระทรวง กระทรวงวิทย์,3101010003,"bale[3101010003][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th3101010004,508,[3101010004]ทุนรับโอน-สวทช.,3101010004,"bale[3101010004][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th3101010005,509,[3101010005]ทุนรับโอน-NECTEC,3101010005,"bale[3101010005][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th3101010006,510,[3101010006]ทุนรับโอนอื่น,3101010006,"bale[3101010006][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th3101010007,511,[3101010007]ทุนที่โอนออก-สวทน.,3101010007,"bale[3101010007][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th3101010008,512,[3101010008]ทุนที่โอนออก-ADTEC,3101010008,"bale[3101010008][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th3101010009,513,[3101010009]ทุนที่โอนออกอื่น,3101010009,"bale[3101010009][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th3101010010,514,[3101010010]ทุนรับโอนโครงการพิเศษทุนประเดิม,3101010010,"bale[3101010010][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th3201010000,515,[3201010000]ส่วนเกินทุนจากการบริจาค,3201010000,"bale[3201010000][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th3201010001,516,[3201010001]ส่วนเกินทุนจากการบริจาค,3201010001,"bale[3201010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th3301010000,517,[3301010000]รายได้สูงกว่า(ต่ำกว่า)ค่าใช้จ่ายสะสม,3301010000,"bale[3301010000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th3301010001,518,[3301010001]รายได้สูงกว่า (ต่ำกว่า) ค่าใช้จ่ายสะสม,3301010001,"bale[3301010001][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external
+mis_report_bs_external_th3301010002,519,[3301010002]กำไร/ขาดทุน ที่ยังไม่เกิดขึ้นในหลักทรัพย์เผื่อขาย,3301010002,"bale[3301010002][('charge_type', '=', 'external')]",text-indent: 50px,2,num,,,pct,mis_report_bs_external

--- a/pabi_mis_account_financial_report/data/mis.report.kpi.csv
+++ b/pabi_mis_account_financial_report/data/mis.report.kpi.csv
@@ -1,4 +1,5 @@
 id,sequence,description,name,expression,default_css_style,dp,type,suffix,prefix,compare_method,report_id/id
+mis_report_bs_th,0,งบแสดงฐานะการเงิน,balance_sheet,bale[1000000000] + bale[2000000000] + bale[3000000000],font-weight: bold,2,num,,,pct,mis_report_bs
 mis_report_bs_th1000000000,1,[1000000000]สินทรัพย์,1000000000,bale[1000000000],font-weight: bold,2,num,,,pct,mis_report_bs
 mis_report_bs_th1100000000,2,[1100000000]สินทรัพย์หมุนเวียน,1100000000,bale[1100000000],font-weight: bold,2,num,,,pct,mis_report_bs
 mis_report_bs_th1101000000,3,[1101000000]เงินสดและรายการเทียบเท่าเงินสด,1101000000,bale[1101000000],font-weight: bold,2,num,,,pct,mis_report_bs

--- a/pabi_mis_account_financial_report/data/mis.report.kpi.csv
+++ b/pabi_mis_account_financial_report/data/mis.report.kpi.csv
@@ -520,6 +520,7 @@ mis_report_bs_th3301010000,517,[3301010000]รายได้สูงกว่�
 mis_report_bs_th3301010001,518,[3301010001]รายได้สูงกว่า (ต่ำกว่า) ค่าใช้จ่ายสะสม,3301010001,bale[3301010001],text-indent: 50px,2,num,,,pct,mis_report_bs
 mis_report_bs_th3301010002,519,[3301010002]กำไร/ขาดทุน ที่ยังไม่เกิดขึ้นในหลักทรัพย์เผื่อขาย,3301010002,bale[3301010002],text-indent: 50px,2,num,,,pct,mis_report_bs
 ,,,,,,,,,,,
+mis_report_bs_internal_th,0,งบแสดงฐานะการเงิน,balance_sheet_internal,bale[1000000000] + bale[2000000000] + bale[3000000000],font-weight: bold,2,num,,,pct,mis_report_bs_internal
 mis_report_bs_internal_th1000000000,1,[1000000000]สินทรัพย์,1000000000,"bale[1000000000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
 mis_report_bs_internal_th1100000000,2,[1100000000]สินทรัพย์หมุนเวียน,1100000000,"bale[1100000000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
 mis_report_bs_internal_th1101000000,3,[1101000000]เงินสดและรายการเทียบเท่าเงินสด,1101000000,"bale[1101000000][('charge_type', '=', 'internal')]",font-weight: bold,2,num,,,pct,mis_report_bs_internal
@@ -1040,6 +1041,7 @@ mis_report_bs_internal_th3301010000,517,[3301010000]รายได้สูง�
 mis_report_bs_internal_th3301010001,518,[3301010001]รายได้สูงกว่า (ต่ำกว่า) ค่าใช้จ่ายสะสม,3301010001,"bale[3301010001][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
 mis_report_bs_internal_th3301010002,519,[3301010002]กำไร/ขาดทุน ที่ยังไม่เกิดขึ้นในหลักทรัพย์เผื่อขาย,3301010002,"bale[3301010002][('charge_type', '=', 'internal')]",text-indent: 50px,2,num,,,pct,mis_report_bs_internal
 ,,,,,,,,,,,
+mis_report_bs_external_th,0,งบแสดงฐานะการเงิน,balance_sheet_external,bale[1000000000] + bale[2000000000] + bale[3000000000],font-weight: bold,2,num,,,pct,mis_report_bs_external
 mis_report_bs_external_th1000000000,1,[1000000000]สินทรัพย์,1000000000,"bale[1000000000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
 mis_report_bs_external_th1100000000,2,[1100000000]สินทรัพย์หมุนเวียน,1100000000,"bale[1100000000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external
 mis_report_bs_external_th1101000000,3,[1101000000]เงินสดและรายการเทียบเท่าเงินสด,1101000000,"bale[1101000000][('charge_type', '=', 'external')]",font-weight: bold,2,num,,,pct,mis_report_bs_external

--- a/pabi_mis_account_financial_report/data/mis_report_bs.xml
+++ b/pabi_mis_account_financial_report/data/mis_report_bs.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record model="mis.report" id="mis_report_bs">
+          <field name="name">Thailand Balance Sheet (All)</field>
+        </record>
+        <record model="mis.report" id="mis_report_bs_internal">
+          <field name="name">Thailand Balance Sheet (Internal)</field>
+        </record>
+        <record model="mis.report" id="mis_report_bs_external">
+          <field name="name">Thailand Balance Sheet (External)</field>
+        </record>
+    </data>
+</openerp>

--- a/pabi_mis_account_financial_report/models/__init__.py
+++ b/pabi_mis_account_financial_report/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2019 Ecosoft Co., Ltd. (https://ecosoft.co.th)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import mis_builders

--- a/pabi_mis_account_financial_report/models/mis_builders.py
+++ b/pabi_mis_account_financial_report/models/mis_builders.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# © 2019 Ecosoft Co., Ltd. (https://ecosoft.co.th)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openerp import api, fields, models
+
+
+class MisReportInstance(models.Model):
+    _inherit = 'mis.report.instance'
+
+    root_account = fields.Many2one(
+        default=lambda l: l._get_root_account()
+    )
+
+    @api.multi
+    def _get_root_account(self):
+        account = self.env['account.account'].search([
+            ('type', '=', 'view'),
+            ('parent_id', '=', False)
+        ])
+        return account.id

--- a/pabi_mis_account_financial_report/models/mis_builders.py
+++ b/pabi_mis_account_financial_report/models/mis_builders.py
@@ -19,3 +19,12 @@ class MisReportInstance(models.Model):
             ('parent_id', '=', False)
         ])
         return account.id
+
+
+class MisReportInstancePeriod(models.Model):
+    _inherit = 'mis.report.instance.period'
+
+    period_special = fields.Boolean(
+        string='Special Period',
+        default=False,
+    )

--- a/pabi_mis_account_financial_report/reports/__init__.py
+++ b/pabi_mis_account_financial_report/reports/__init__.py
@@ -2,5 +2,4 @@
 # © 2019 Ecosoft Co., Ltd. (https://ecosoft.co.th)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from . import models
-from . import reports
+from . import mis_builder_xlsx

--- a/pabi_mis_account_financial_report/reports/mis_builder_xlsx.py
+++ b/pabi_mis_account_financial_report/reports/mis_builder_xlsx.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Ecosoft Co., Ltd (http://ecosoft.co.th/)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
+
+from types import CodeType
+from openerp.addons.pabi_report_xlsx_helper.report.report_xlsx_abstract \
+    import ReportXlsxAbstract
+from openerp import _
+
+
+class MISReportInstanceXlsx(ReportXlsxAbstract):
+
+    def _write_header(self, ws, row_pos, ws_params, width,
+                      render_space=None, default_format=None):
+        pos = 0
+        # first column is null
+        for val in range(2):
+            ws.write_string(row_pos+val, pos, '', default_format)
+        pos += 1
+        for col in ws_params:
+            ws.set_column(pos, pos, width)
+            colspan = 1
+            cell_value = col.get('name')
+            cell_value_date = col.get('date')
+            cell_format = default_format
+            cell_type = 'string'
+            args_pos = [row_pos, pos]
+            args_data = [cell_value]
+            if cell_format:
+                if isinstance(cell_format, CodeType):
+                    cell_format = self._eval(cell_format, render_space)
+                args_data.append(cell_format)
+            ws_method = getattr(ws, 'write_%s' % cell_type)
+            args = args_pos + args_data
+            ws_method(*args)
+            # loop create header date
+            row = row_pos + 1
+            args_pos = [row, pos]
+            args_data = [cell_value_date]
+            if cell_format:
+                if isinstance(cell_format, CodeType):
+                    cell_format = self._eval(cell_format, render_space)
+                args_data.append(cell_format)
+            args = args_pos + args_data
+            ws_method(*args)
+            pos += colspan
+        return row + 1
+
+    def _get_ws_params(self, wb, data, mis_report):
+        mis_template = {
+            'kpi': {
+                'data': {
+                    'value': self._render('kpi_name'),
+                },
+                'width': 60,
+            },
+        }
+        ws_params = {
+            'ws_name': '%s' % mis_report.name,
+            'generate_ws_method': '_mis_builder_report',
+            'title': _('%s - %s') % (
+                mis_report.name, mis_report.company_id.name),
+            'wanted_list': [str(x) for x in sorted(mis_template.keys())],
+            'col_specs': mis_template,
+        }
+        return [ws_params]
+
+    def _mis_builder_report(self, workbook, ws, ws_params, data, mis_report):
+        ws.set_portrait()
+        ws.fit_to_pages(1, 0)
+        ws.set_header(self.xls_headers['standard'])
+        ws.set_footer(self.xls_footers['standard'])
+        # Set font name
+        font_name = 'Arial'
+        workbook.formats[0].set_font_name(font_name)
+
+        self._set_column_width(ws, ws_params)
+
+        row_pos = 0
+        row_pos = self._write_ws_title(ws, row_pos, ws_params)
+        # get all data
+        data_dict = mis_report.compute()
+        # Column Headers
+        width = 25
+        row_pos = self._write_header(
+            ws, row_pos, data_dict['header'][0]['cols'],
+            width, default_format=self.format_theader_yellow_amount_right)
+        # freeze header and left
+        ws.freeze_panes(row_pos, 1)
+        for line in data_dict['content']:
+            style = ''
+            if 'text-indent' in line.get('default_style'):
+                len_indent = line.get('default_style').split(':')[1].strip()
+                # indent < 100 px
+                if len(len_indent) <= 4:
+                    format_css = self.format_indent_1
+                else:
+                    format_css = self.format_indent_2
+            if 'font-weight' in line.get('default_style'):
+                style = line.get('default_style').split(':')[1].strip()
+                format_css = workbook.add_format(
+                    {'align': 'left', u'{}'.format(style): True,
+                     'font_name': font_name})
+            row_pos = self._write_line(
+                ws, row_pos, ws_params, col_specs_section='data',
+                render_space={
+                    'kpi_name': line['kpi_name'],
+                },
+                default_format=format_css)
+            col = 0
+            for value in line['cols']:
+                col += 1
+                # style
+                num_format_str = '#,##0'
+                if value.get('dp'):
+                    num_format_str += '.'
+                    num_format_str += '0' * int(value['dp'])
+                if value.get('prefix'):
+                    num_format_str = '"%s" %s' % \
+                        (value['prefix'], num_format_str)
+                if value.get('suffix'):
+                    num_format_str += ' "%s"' % value['suffix']
+                self.format_amount_mis_right = workbook.add_format(
+                    {'align': 'right', 'num_format': num_format_str,
+                     'font_name': font_name})
+                if style:
+                    self.format_amount_mis_right = workbook.add_format(
+                        {'align': 'right', 'num_format': num_format_str,
+                         u'{}'.format(style): True, 'font_name': font_name})
+
+                if value.get('val'):
+                    val = value['val']
+                    if value.get('is_percentage'):
+                        val = val / 0.01
+                    ws.write(row_pos-1, col, val, self.format_amount_mis_right)
+                else:
+                    ws.write(row_pos-1, col, value['val_r'],
+                             self.format_amount_mis_right)
+
+
+MISReportInstanceXlsx('report.mis_report_instance_xlsx', 'mis.report.instance')

--- a/pabi_mis_account_financial_report/views/mis_builder.xml
+++ b/pabi_mis_account_financial_report/views/mis_builder.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+
+        <record id="mis_report_instance_view_form" model="ir.ui.view">
+            <field name="name">mis.report.instance.view.form</field>
+            <field name="model">mis.report.instance</field>
+            <field name="inherit_id" ref="mis_builder.mis_report_instance_view_form"/>
+            <field name="arch" type="xml">
+                <field name="comparison_column_ids" position="after">
+                    <field name="period_special" attrs="{'invisible': [('type', '!=', 'fp')]}"/>
+                </field>
+            </field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
เปลี่ยนวิธีการรันรายงานเป็นแบบ MIS Builder
สามารถรันออกมาได้ทั้ง 3 แบบ คือ view, pdf และ excel
วิธีการใช้งาน
1. install module mis_builder
2. install module pabi_mis_account_financial_report
3. go to Accounting -> Reporting -> MIS Reports
4. create mis และเลือก Report ที่ต้องการ (ตัวอย่างจะทำ งบแสดงฐานะทางการเงิน)
5. ใน line เลือก Period type -> Fiscal Period และ set ช่วงเวลาที่ต้องการดู
6. save และสามารถดู Preview, PDF, Excel ได้ที่ปุ่มด้านขวา

การใช้ CSS Style Sheet
สำหรับการ Export เป็น Excel จะมีข้อจำกัดคือ
- การใช้ `text-indent` สามารถทำได้สูงสุด 2 ชั้นคือ
  `text-indent: 50px` = indent 1 ชั้น
  `text-indent: 100px` = indent 2 ชั้น