### PR TITLE
#4104 [FIX] move_id in first asset line type expense_to_asset

### DIFF
--- a/pabi_asset_management/models/asset_adjust.py
+++ b/pabi_asset_management/models/asset_adjust.py
@@ -785,6 +785,8 @@ class AccountAssetAdjust(models.Model):
             line.move_id = move
             # Set move_check equal to amount depreciated
             depre_lines.write({'move_id': move.id})
+            if not depre_lines:
+                new_asset.depreciation_line_ids[0].write({'move_id': move.id})
 
     @api.model
     def _setup_move_data(self, journal, adjust_date,


### PR DESCRIPTION
แก้ไขให้ asset line จับคู่กับ move ให้ถูกต้อง