### PR TITLE
#4143 - Smart Button แสดงข้อมูล Assets หลังจากถูก Remove หายไป

### DIFF
--- a/pabi_asset_management/models/stock.py
+++ b/pabi_asset_management/models/stock.py
@@ -46,13 +46,17 @@ class StockPicking(models.Model):
         assets = Asset.with_context(active_test=False).search([('picking_id',
                                                                 '=', self.id)])
         dom = [('id', 'in', assets.ids)]
-        result.update({'domain': dom})
+        result.update({
+            'domain': dom,
+            'context': {'active_test': False},
+        })
         return result
 
     @api.multi
     def _compute_assset_count(self):
         for rec in self:
-            rec.asset_count = len(rec.asset_ids)
+            rec.asset_count = len(rec.with_context(active_test=False).
+                                  asset_ids)
 
     @api.multi
     def open_entries(self):


### PR DESCRIPTION
จากที่ได้ตรวจสอบปัญหาพบว่าเกิดจาก
- สถานะของ Asset เป็น active = False ทำให้ระบบไม่สามารถนับจำนวน Asset ที่เกิด/เคยเกิดขึ้นได้
จึงเกิดกรณีที่ เมื่อทำการยกเลิก Asset ปุ่ม Smart Button หายไป

ทำการแก้ไขโดย
- ให้ระบบทำการนับ Asset ที่เกิดขึ้น
![Selection_043](https://user-images.githubusercontent.com/52144935/72499962-d97e3200-3865-11ea-9986-b6e4684832bc.png)

- เมื่อกดปุ่ม smart button "Assets" จะแสดง Assets ที่เกิดขึ้น (Active = False and True)
![Selection_044](https://user-images.githubusercontent.com/52144935/72499976-e3079a00-3865-11ea-8552-e8461647efde.png)
