### PR TITLE
[FIX] 4193: hide_action_delete in PO Contract

### DIFF
--- a/pabi_purchase_contract/views/purchase_contract_view.xml
+++ b/pabi_purchase_contract/views/purchase_contract_view.xml
@@ -156,6 +156,7 @@
             <xpath expr="/form" position="attributes">
                 <attribute name="create">1</attribute>
                 <attribute name="edit">1</attribute>
+				<attribute name="delete">false</attribute>
             </xpath>
         </field>
     </record>
@@ -177,7 +178,7 @@
 			<field name="name">purchase.contract.tree</field>
 			<field name="model">purchase.contract</field>
 			<field name="arch" type="xml">
-				<tree string="PO Contract" colors="red:state=='cancel_generate';red:state=='terminate' ">
+				<tree string="PO Contract" colors="red:state=='cancel_generate';red:state=='terminate' " delete="false">
 					<field name="display_code"/>
 					<field name="contract_type_id"/>
 					<field name="name"/>


### PR DESCRIPTION
Issue : https://mobileapp.nstda.or.th/redmine/issues/4193

ซ่อนปุ่ม Delete ที่ tree/form view in PO Contract

![Selection_138](https://user-images.githubusercontent.com/52144935/73427803-33a0ec00-436a-11ea-8ea0-18a0a011614b.png)
![Selection_137](https://user-images.githubusercontent.com/52144935/73427806-33a0ec00-436a-11ea-8c02-1bc9a8b697ab.png)

Update This Only : Module - pabi_purchase_contract
