### PR TITLE
#4206 [FIX] asset and journal import

### DIFF
--- a/pabi__pre_go_live/__openerp__.py
+++ b/pabi__pre_go_live/__openerp__.py
@@ -7,6 +7,7 @@
     "description": """
 
 * Allow create / duplicate purchase
+* Allow create / import journal entries
 
     """,
     "website": "https://ecosoft.co.th/",
@@ -20,6 +21,7 @@
         "pabi_invest_construction",
         "pabi_asset_management",
         "purchase_invoice_plan",
+        "account",
     ],
     "data": [
         "views/purchase_requisition_view.xml",
@@ -28,5 +30,6 @@
         "views/hr_expense_view.xml",
         "views/invest_construction_view.xml",
         "views/asset_view.xml",
+        "views/account_view.xml",
     ],
 }

--- a/pabi__pre_go_live/models/__init__.py
+++ b/pabi__pre_go_live/models/__init__.py
@@ -5,3 +5,4 @@ from . import purchase_request
 from . import hr_expense
 from . import asset
 from . import purchase
+from . import account_move

--- a/pabi__pre_go_live/models/account_move.py
+++ b/pabi__pre_go_live/models/account_move.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+from openerp import api, models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = 'account.move.line'
+
+    @api.model
+    def create(self, vals, **kwargs):
+        ctx = self._context.copy()
+        ctx.update({'allow_asset': True})
+        return super(AccountMoveLine, self).create(vals)

--- a/pabi__pre_go_live/models/asset.py
+++ b/pabi__pre_go_live/models/asset.py
@@ -26,3 +26,7 @@ class AccountAsset(models.Model):
     owner_invest_construction_phase_id = fields.Many2one(
         readonly=False,
     )
+    purchase_id = fields.Many2one(
+        related=False,
+        states={'draft': [('readonly', False)]}
+    )

--- a/pabi__pre_go_live/views/account_view.xml
+++ b/pabi__pre_go_live/views/account_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_move_tree" model="ir.ui.view">
+            <field name="name">view.move.tree</field>
+            <field name="model">account.move</field>
+            <field name="inherit_id" ref="pabi_account.view_move_tree"/>
+            <field name="arch" type="xml">
+                <tree position="attributes">
+                    <attribute name="create">1</attribute>
+                </tree>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
**Deployment** : restart and install module `pabi__pre_go_live`
แก้ไขให้ระบบสามารถ import journal entries ได้ เมื่อ install module `pabi__pre_go_live`

- เปิด field Purchase Order ให้สามารถ import ได้ โดยการเพิ่ม `purchase_id` ใน template import asset
ตัวอย่าง template -> [sample_Import_Asset.xlsx](https://github.com/pabi2/pb2_addons/files/4159197/sample_Import_Asset.xlsx)

- เปิดให้ระบบสามารถ import journal entries ได้ ที่เมนู
Accounting > Journal Entries > Journal Entries
ตัวอย่าง template -> [2020-02-02_upload_DECC.xlsx](https://github.com/pabi2/pb2_addons/files/4159214/2020-02-02_upload_DECC.xlsx)
