### PR TITLE
#4265 [FIX] asset to expense

### DIFF
--- a/pabi_asset_management/models/asset_adjust.py
+++ b/pabi_asset_management/models/asset_adjust.py
@@ -1221,7 +1221,7 @@ class AccountAssetAdjustAssetToExpense(MergedChartField, ActivityCommon,
             old_asset_credit = AssetAdjust._setup_move_line_data(
                 old_asset.code, old_asset, period, old_asset_acc, adjust_date,
                 debit=False, credit=purchase_value,
-                analytic_id=False)
+                analytic_id=old_asset.account_analytic_id.id)
             line_dict += [(0, 0, expense_debit), (0, 0, old_asset_credit)]
         # Dr: old - depre accum value (account_depreciation_id)
         #   Cr: old - depre value (account_expense_depreciation_id)(budget)


### PR DESCRIPTION
แก้ไขการที่ asset_to_expense ไม่สามารถ adjust ได้
สาเหตุเกิดจาก move line ของ asset เก่า ไม่มีค่า account analytic
ทำให้ระบบไม่ได้คืน budget กลับ ส่งผลให้ budget นั้นๆมียอดเป็น 2 เท่า
แก้ไขโดยการเพิ่ม account analytic เพื่อให้ระบบสามารถคืน budget ได้ถูกต้อง

deployment : restart only