### PR TITLE
#4261 [FIX] project_interface_expense error

### DIFF
--- a/pabi_my_project/models/res_project.py
+++ b/pabi_my_project/models/res_project.py
@@ -523,9 +523,19 @@ class ResProject(LogCommon, models.Model):
             budget_monitor = project.monitor_expense_ids.filtered(lambda l: l.fiscalyear_id == fiscalyear and l.budget_method=='expense' and l.charge_type=='external')
             budget_plans.write({'released_amount': 0.0})  # Set zero
             if release_external_budget:  # Only for external charge
-                budget_plans = budget_plans.filtered(
-                    lambda l: l.charge_type == 'external'
-                    and l.budget_method == 'expense')
+                # All expense
+                expense_budget_plans = budget_plans.filtered(
+                    lambda l: l.budget_method == 'expense')
+                # Filter only internal
+                int_budget_plans = expense_budget_plans.filtered(
+                    lambda l: l.charge_type == 'internal')
+                # Filter only extenral
+                budget_plans = expense_budget_plans.filtered(
+                    lambda l: l.charge_type == 'external')
+                # Check case internal but not external, just return, no error
+                if int_budget_plans and not budget_plans:
+                    return
+
             if not budget_plans:
                 raise ValidationError(
                     _('Not allow to release budget for project without plan!'))


### PR DESCRIPTION
แก้ไขเมื่อระบบอื่นส่งค่า budget plan expense แต่ไม่ส่งปีที่เคยมีในระบบมา
ให้ระบบตรวจสอบ budget_plan_ids ถ้ามี internal จะให้ระบบ return ค่ากลับไม่ต้อง released amount

deployment : restart only