### PR TITLE
#4314 [FIX] performance turning WA case invoice plan

### DIFF
--- a/pabi_purchase_work_acceptance/models/purchase_work_acceptance.py
+++ b/pabi_purchase_work_acceptance/models/purchase_work_acceptance.py
@@ -592,7 +592,13 @@ class PurchaseWorkAcceptance(models.Model):
                         wa_line.inv_line_id.invoice_id.state == 'draft':
                     wa_line.inv_line_id.quantity = wa_line.to_receive_qty
                     wa_line.inv_line_id.price_unit = wa_line.price_unit
-                    wa_line.inv_line_id.invoice_id.button_reset_taxes()
+                    # wa_line.inv_line_id.invoice_id.button_reset_taxes()
+
+            invoice_ids = wa.acceptance_line_ids.filtered(
+                lambda l: l.inv_line_id.invoice_id and
+                l.inv_line_id.invoice_id.state == 'draft'
+                ).mapped('inv_line_id.invoice_id')
+            invoice_ids.button_reset_taxes()
 
     @api.multi
     @api.depends('acceptance_line_ids.price_subtotal',

--- a/pabi_purchase_work_acceptance/wizard/create_purchase_work_acceptance.py
+++ b/pabi_purchase_work_acceptance/wizard/create_purchase_work_acceptance.py
@@ -202,21 +202,21 @@ class CreatePurchaseWorkAcceptance(models.TransientModel):
     @api.model
     def _prepare_acceptance(self):
         lines = []
-        vals = {}
+        # vals = {}
         PWAcceptance = self.env['purchase.work.acceptance']
-        vals.update({
-            'name': self.env['ir.sequence'].get('purchase.work.acceptance'),
-            'date_scheduled_end': self.date_scheduled_end,
-            'date_contract_start': self.date_contract_start,
-            'date_contract_end': self.date_scheduled_end,
-            'date_receive': self.date_receive,
-            'order_id': self.order_id.id,
-            'supplier_invoice': '-',
-            'date_invoice': self.date_receive,
-            'total_fine': 0,
-            'installment': self.select_invoice_plan,
-        })
-        acceptance = PWAcceptance.create(vals)
+        # vals.update({
+        #     'name': self.env['ir.sequence'].get('purchase.work.acceptance'),
+        #     'date_scheduled_end': self.date_scheduled_end,
+        #     'date_contract_start': self.date_contract_start,
+        #     'date_contract_end': self.date_scheduled_end,
+        #     'date_receive': self.date_receive,
+        #     'order_id': self.order_id.id,
+        #     'supplier_invoice': '-',
+        #     'date_invoice': self.date_receive,
+        #     'total_fine': 0,
+        #     'installment': self.select_invoice_plan,
+        # })
+        # acceptance = PWAcceptance.create(vals)
         if self.is_invoice_plan:
             items = \
                 self._prepare_acceptance_plan_line(self.select_invoice_plan)
@@ -235,7 +235,21 @@ class CreatePurchaseWorkAcceptance(models.TransientModel):
                     'price_unit': act_line.line_id.price_unit,
                 }
                 lines.append([0, 0, line_vals])
-        acceptance.write({'acceptance_line_ids': lines})
+        vals = {
+            'name': self.env['ir.sequence'].get('purchase.work.acceptance'),
+            'date_scheduled_end': self.date_scheduled_end,
+            'date_contract_start': self.date_contract_start,
+            'date_contract_end': self.date_scheduled_end,
+            'date_receive': self.date_receive,
+            'order_id': self.order_id.id,
+            'supplier_invoice': '-',
+            'date_invoice': self.date_receive,
+            'total_fine': 0,
+            'installment': self.select_invoice_plan,
+            'acceptance_line_ids': lines,
+        }
+        acceptance = PWAcceptance.create(vals)
+        # acceptance.write({'acceptance_line_ids': lines})
         acceptance._compute_total_fine()
         return acceptance
 


### PR DESCRIPTION
Performance WA
---------------------------------------
- แก้ไขการสร้าง WA
จากเดิม สร้าง WA แล้ว write wa_line ทับไปอีกทีหนึ่ง
แก้เป็น สร้าง wa_line ให้เสร็จก่อน (เป็น dict) แล้วสร้าง WA พร้อม line ทีเดียว

- แก้ไขการเรียกใช้งาน function button_reset_taxes
จากเดิมระบบจะเรียก function นี้ทุกครั้ง ทีละครั้งใช้เวลาประมาณ 0.8 วินาที
แก้เป็น วน loops เก็บค่า invoices ทั้งหมดมาก่อนแล้วค่อยเรียก function นี้ทีเดียว

วิธีทดสอบ
1. สร้าง PO Lines 10 บรรทัด เลือก use invoice plan
2. แบ่งเป็น 2 งวด -> Create Invoices
3. Create Work Acceptance เลือกจ่ายงวดที่ 1

ผลการทดสอบ
จากเดิมใช้เวลา 60 วินาที เหลือ 8 วินาที

Deployment : Restart only