### PR TITLE
#4416 - mis_builder

### DIFF
--- a/pabi_mis_account_financial_report/reports/mis_builder_xlsx.py
+++ b/pabi_mis_account_financial_report/reports/mis_builder_xlsx.py
@@ -96,10 +96,16 @@ class MISReportInstanceXlsx(ReportXlsxAbstract):
                     format_css = self.format_indent_1
                 else:
                     format_css = self.format_indent_2
+            datas = [l.strip() for l in line.get('default_style').split(';')]
+            talign = 'left'
+            for rec in datas:
+                if 'text-align' in rec:
+                    talign = rec.split(':')[1].strip()
+                if 'font-weight' in rec:
+                    style = rec.split(':')[1].strip()
             if 'font-weight' in line.get('default_style'):
-                style = line.get('default_style').split(':')[1].strip()
                 format_css = workbook.add_format(
-                    {'align': 'left', u'{}'.format(style): True,
+                    {'align': talign, u'{}'.format(style): True,
                      'font_name': font_name})
             row_pos = self._write_line(
                 ws, row_pos, ws_params, col_specs_section='data',


### PR DESCRIPTION
Issue: https://mobileapp.nstda.or.th/redmine/issues/4416
Deployment: Restart

กรณีกำหนดค่า default_css_style = font-weight: bold; text-align: right; สามารถแสดงผลใน XLSX ให้เป็น "ตัวหนา และ ชิดทางด้านขวา" ได้

PDF: https://github.com/pabi2/pb2_base_technical/pull/44

![Selection_198](https://user-images.githubusercontent.com/52144935/79188872-7131f300-7e4a-11ea-85de-d666f8584042.png)
![Selection_199](https://user-images.githubusercontent.com/52144935/79188907-8a3aa400-7e4a-11ea-88a9-6a2b0aff0cc9.png)
