### PR TITLE
#4429 [FIX] change analytic_line for check after create only

### DIFF
--- a/account_budget_activity/models/account_move_line.py
+++ b/account_budget_activity/models/account_move_line.py
@@ -41,7 +41,7 @@ class AccountMoveLine(models.Model):
         if vals.get('analytic_account_id', False):
             analytic = Analytic.browse(vals['analytic_account_id'])
         if analytic:
-            analytic._check_analytic_asset_line(vals)
+            # analytic._check_analytic_asset_line(vals)
             domain = Analytic.get_analytic_search_domain(analytic)
             vals.update(dict((x[0], x[2]) for x in domain))
         return vals

--- a/account_budget_activity/models/analytic.py
+++ b/account_budget_activity/models/analytic.py
@@ -234,27 +234,51 @@ class AccountAnalyticLine(models.Model):
 
     @api.multi
     def _check_analytic_asset_line(self):
-        MOVE = self.env['account.move']#
+        self.ensure_one()
         ASSET_line = self.env['account.asset.line']
-        #moves = MOVE.browse(self.move_id and self.move_id.id)
+        # move function from account_analytic_account
+        # if self.move_id and self.move_id.move_id:
+        #     asset_id = ASSET_line.search([
+        #         ('move_id', '=', self.move_id.move_id.id),
+        #         ('asset_id', '!=', False)
+        #     ], limit=1).asset_id
+        #     if asset_id:
+        #         self.account_id.write({
+        #             'section_id': asset_id.owner_section_id.id or False,
+        #             'project_id': asset_id.owner_project_id.id or False,
+        #             'invest_asset_id':
+        #                 asset_id.owner_invest_asset_id.id or False,
+        #             'invest_construction_phase_id':
+        #                 asset_id.owner_invest_construction_phase_id.id
+        #                 or False,
+        #             'costcenter_id': asset_id.owner_section_id.costcenter_id.id
+        #             or asset_id.owner_project_id.costcenter_id.id
+        #             or asset_id.owner_project_id.costcenter_id.id
+        #             or asset_id.owner_invest_construction_phase_id.
+        #                 costcenter_id.id,
+        #         })
+
         if self.move_id:
-            depreciation_lines = ASSET_line.search([('move_id','=',self.move_id.id),('asset_id','!=',False)])
+            depreciation_lines = ASSET_line.search([
+                ('move_id', '=', self.move_id.id),
+                ('asset_id', '!=', False)])
             if depreciation_lines:
-                self.section_id = depreciation_lines[0].asset_id.owner_section_id and\
-                                    depreciation_lines[0].asset_id.owner_section_id.id or False
-                self.project_id = depreciation_lines[0].asset_id.owner_project_id and\
-                                    depreciation_lines[0].asset_id.owner_project_id.id or False
-                self.invest_asset_id = depreciation_lines[0].asset_id.owner_invest_asset_id and\
-                                        depreciation_lines[0].asset_id.owner_invest_asset_id.id or False
-                self.invest_construction_phase_id = depreciation_lines[0].asset_id.owner_invest_construction_phase_id and\
-                                                        depreciation_lines[0].asset_id.owner_invest_construction_phase_id.id or False
-                chartfield_id = self.section_id or\
-                                self.project_id or\
-                                self.invest_asset_id or\
-                                self.invest_construction_phase_id or False
-                self.costcenter_id = chartfield_id and\
-                                        chartfield_id.costcenter_id and\
-                                        chartfield_id.costcenter_id.id or False
+                asset_id = depreciation_lines[0].asset_id
+                self.section_id = asset_id.owner_section_id and \
+                    asset_id.owner_section_id.id or False
+                self.project_id = asset_id.owner_project_id and \
+                    asset_id.owner_project_id.id or False
+                self.invest_asset_id = asset_id.owner_invest_asset_id and \
+                    asset_id.owner_invest_asset_id.id or False
+                self.invest_construction_phase_id = \
+                    asset_id.owner_invest_construction_phase_id and \
+                    asset_id.owner_invest_construction_phase_id.id or False
+                chartfield_id = self.section_id or self.project_id or \
+                    self.invest_asset_id or self.invest_construction_phase_id \
+                    or False
+                self.costcenter_id = chartfield_id and \
+                    chartfield_id.costcenter_id and \
+                    chartfield_id.costcenter_id.id or False
 
     @api.model
     def create(self, vals):
@@ -342,61 +366,63 @@ class AccountAnalyticAccount(models.Model):
         ]
         return dimensions
 
-    @api.multi
-    def _check_analytic_asset_line(self, vals):
-        MOVE = self.env['account.move']
-        ASSET = self.env['account.asset']
-        ASSET_line = self.env['account.asset.line']
-        asset_id = False
-        # moves = MOVE.browse(self.move_id and self.move_id.id)
-        if 'asset_id' in vals:
-            asset_id = ASSET.browse(vals['asset_id'])
-        if self.line_ids and self.line_ids.sorted()[0].move_id \
-                and self.line_ids.sorted()[0].move_id.move_id:
-            asset_id = ASSET_line.search([
-                ('move_id', '=', self.line_ids.sorted()[0].move_id.move_id.id),
-                ('asset_id', '!=', False)
-            ], limit=1).asset_id
-        # if not self.line_ids:
-        #     asset_id = ASSET.search([
-        #         ('account_analytic_id', '=', self.id),
-        #         ('active', '=', True)
-        #     ], limit=1)
-
-        if asset_id:
-            if asset_id.owner_section_id:
-                self.write({
-                            'section_id': asset_id.owner_section_id.id,
-                            'project_id': False,
-                            'invest_asset_id': False,
-                            'invest_construction_phase_id': False,
-                            'costcenter_id':
-                            asset_id.owner_section_id.costcenter_id.id,
-                    })
-            elif asset_id.owner_project_id:
-                self.write({
-                            'section_id': False,
-                            'project_id': asset_id.owner_project_id.id,
-                            'invest_asset_id': False,
-                            'invest_construction_phase_id': False,
-                            'costcenter_id': asset_id.owner_project_id.costcenter_id.id,
-                    })
-            elif asset_id.owner_invest_asset_id:
-                self.write({
-                            'section_id': False,
-                            'project_id': False,
-                            'invest_asset_id': asset_id.owner_invest_asset_id.id,
-                            'invest_construction_phase_id': False,
-                            'costcenter_id': asset_id.owner_invest_asset_id.costcenter_id.id,
-                    })
-            elif asset_id.owner_invest_construction_phase_id:
-                self.write({
-                            'section_id': False,
-                            'project_id': False,
-                            'invest_asset_id': False,
-                            'invest_construction_phase_id': asset_id.owner_invest_construction_phase_id.id,
-                            'costcenter_id': asset_id.owner_invest_construction_phase_id.costcenter_id.id,
-                    })
+    # @api.multi
+    # def _check_analytic_asset_line(self, vals):
+    #     MOVE = self.env['account.move']
+    #     ASSET = self.env['account.asset']
+    #     ASSET_line = self.env['account.asset.line']
+    #     asset_id = False
+    #     print(self.line_ids)
+    #     print("============line===========")
+    #     # moves = MOVE.browse(self.move_id and self.move_id.id)
+    #     if 'asset_id' in vals:
+    #         asset_id = ASSET.browse(vals['asset_id'])
+    #     if self.line_ids and self.line_ids.sorted()[0].move_id \
+    #             and self.line_ids.sorted()[0].move_id.move_id:
+    #         asset_id = ASSET_line.search([
+    #             ('move_id', '=', self.line_ids.sorted()[0].move_id.move_id.id),
+    #             ('asset_id', '!=', False)
+    #         ], limit=1).asset_id
+    #     # if not self.line_ids:
+    #     #     asset_id = ASSET.search([
+    #     #         ('account_analytic_id', '=', self.id),
+    #     #         ('active', '=', True)
+    #     #     ], limit=1)
+    #
+    #     if asset_id:
+    #         if asset_id.owner_section_id:
+    #             self.write({
+    #                         'section_id': asset_id.owner_section_id.id,
+    #                         'project_id': False,
+    #                         'invest_asset_id': False,
+    #                         'invest_construction_phase_id': False,
+    #                         'costcenter_id':
+    #                         asset_id.owner_section_id.costcenter_id.id,
+    #                 })
+    #         elif asset_id.owner_project_id:
+    #             self.write({
+    #                         'section_id': False,
+    #                         'project_id': asset_id.owner_project_id.id,
+    #                         'invest_asset_id': False,
+    #                         'invest_construction_phase_id': False,
+    #                         'costcenter_id': asset_id.owner_project_id.costcenter_id.id,
+    #                 })
+    #         elif asset_id.owner_invest_asset_id:
+    #             self.write({
+    #                         'section_id': False,
+    #                         'project_id': False,
+    #                         'invest_asset_id': asset_id.owner_invest_asset_id.id,
+    #                         'invest_construction_phase_id': False,
+    #                         'costcenter_id': asset_id.owner_invest_asset_id.costcenter_id.id,
+    #                 })
+    #         elif asset_id.owner_invest_construction_phase_id:
+    #             self.write({
+    #                         'section_id': False,
+    #                         'project_id': False,
+    #                         'invest_asset_id': False,
+    #                         'invest_construction_phase_id': asset_id.owner_invest_construction_phase_id.id,
+    #                         'costcenter_id': asset_id.owner_invest_construction_phase_id.costcenter_id.id,
+    #                 })
 
     @api.model
     def get_analytic_search_domain(self, rec):

--- a/pabi_asset_management/models/asset.py
+++ b/pabi_asset_management/models/asset.py
@@ -499,12 +499,13 @@ class AccountAsset(ChartFieldAction, models.Model):
 
     @api.multi
     def validate_asset_to_removal(self):
-        invalid_assets = self.filtered(lambda l: l.type != 'normal' or l.state not in ('open','close')).mapped('code')
-
-        if len(invalid_assets) > 0:
+        invalid_assets = self.filtered(
+            lambda l: l.type != 'normal' or l.state not in ('open', 'close')
+            ).mapped('code')
+        if invalid_assets:
             raise ValidationError(
                 _('Please select running or close assets!\n'
-                  'Asset error : %s'%str(tuple(invalid_assets))))
+                  'Asset error : %s' % str(tuple(invalid_assets))))
 
     @api.multi
     def action_undeliver_assets(self):
@@ -703,6 +704,9 @@ class AccountAsset(ChartFieldAction, models.Model):
             return line_dates
         # Import asset batch
         if not asset_line:
+            # Import 1 asset line will return original asset line
+            if len(first_asset) <= 1:
+                return line_dates
             init_last_date = \
                 fields.Datetime.from_string(first_asset[-1].line_date)
             line_dates = [line for line in all_dates if line >= init_last_date]

--- a/pabi_asset_management/wizard/account_asset_remove.py
+++ b/pabi_asset_management/wizard/account_asset_remove.py
@@ -32,5 +32,20 @@ class AccountAssetRemove(models.TransientModel):
         self = self.with_context(overwrite_move_name='/')
         res = super(AccountAssetRemove, self).remove()
         asset.status = self.target_status
-        asset.active = False
+        return res
+
+    def _get_removal_data(self, asset, residual_value):
+        res = super(AccountAssetRemove, self)._get_removal_data(
+            asset, residual_value)
+        chartfield_id = asset.owner_section_id or asset.owner_project_id or \
+            asset.owner_invest_asset_id or \
+            asset.owner_invest_construction_phase_id or False
+        asset.account_analytic_id.write({
+            'section_id': asset.owner_section_id.id or False,
+            'project_id': asset.owner_project_id.id or False,
+            'invest_asset_id': asset.owner_invest_asset_id.id or False,
+            'invest_construction_phase_id':
+                asset.owner_invest_construction_phase_id.id or False,
+            'costcenter_id': chartfield_id.costcenter_id.id or False,
+        })
         return res


### PR DESCRIPTION
สาเหตุอาจเกิดจากการที่มีการ check ก่อนสร้าง analytic_line
ซึ่งจะเกิดกรณีที่สร้าง PO lines หลายบรรทัด แล้วระบบสร้าง analytic line ไม่ทัน
ทำให้บางค่าระบบไม่เจอ line แล้วจึงข้ามบางขั้นตอนไป

- แก้ไขการ check เงื่อนไขหลังสร้าง analytic_line ซึ่งจะมั่นใจได้ว่าเกิด analytic_line แน่นอน
ฉะนั้นระบบจะทำงานถูกต้อง เมื่อมีการสร้างหลายๆ PO lines

- แก้ไขการบันทึก OU ของ asset โดยใช้ owner_OU_id แทน OU_id เมื่อ remove asset จากทั้ง master asset และ action removal

- แก้ไขการบันทึก move line กรณีที่เกิดผลต่าง โดยดูจาก Removal Entry Policy
-- กรณีที่เป็น gain/loss แล้วมีผลต่าง ระบบจะสร้าง move_line อีกบรรทัด โดยดู account จาก min value account (dr.) และ plus value account (cr.)
-- กรณีที่เป็น residual value แล้วมีผลต่าง ระบบจะสร้าง move_line โดยดู account จาก residual value account

Deployment : Restart and update module
- account_budget_activity
- pabi_budget_monitor
- pabi_budget_plan_monitor
- pabi_etl