### PR TITLE
#4466 [FIX] error when create new myproject

### DIFF
--- a/pabi_budget_monitor/models/res_spa_structure.py
+++ b/pabi_budget_monitor/models/res_spa_structure.py
@@ -218,6 +218,9 @@ class ResProject(models.Model):
     @api.multi
     def _compute_budget_monitor(self):
         self.ensure_one()
+        # create new project not query
+        if not isinstance(self.id, int):
+            return True
         # delete all record and create new for performance on menu myProject
         self._cr.execute("""delete from res_project_monitor_only_view""")
         self._cr.execute("""


### PR DESCRIPTION
แก้ไข error เมื่อสร้าง project ใหม่

สาเหตุเกิดจากระบบเป็น compute field และมีการ query ทุกครั้งที่มีการเปลี่ยนแปลง
แต่ id ที่ส่งมาเมื่อสร้าง project ใหม่ยังไม่มี ระบบจึง query หา id นั้นไม่เจอจึงเกิด error

แก้ไขโดยการ check id ก่อน ถ้าไม่มี id ให้ return ค่ากลับไป ไม่ต้อง query

deployment : restart only