### PR TITLE
#4459 - Fix account_id when create from Inventory Adjustments

### DIFF
--- a/pabi_account_move_adjustment/models/stock_account.py
+++ b/pabi_account_move_adjustment/models/stock_account.py
@@ -11,6 +11,10 @@ class StockQuant(models.Model):
                                   journal_id, context=None):
         # send context stock to account_move
         context.update({'stock_move_id': move})
+        if context.get('default_inv_adjust'):
+            acc_output = move.product_id.categ_id.\
+                property_stock_account_output_categ.id
+            credit_account_id = acc_output
         res = super(StockQuant, self)._create_account_move_line(
                 cr, uid, quants, move, credit_account_id, debit_account_id,
                 journal_id, context)

--- a/pabi_account_move_adjustment/models/stock_account.py
+++ b/pabi_account_move_adjustment/models/stock_account.py
@@ -10,11 +10,17 @@ class StockQuant(models.Model):
                                   credit_account_id, debit_account_id,
                                   journal_id, context=None):
         # send context stock to account_move
+        location_obj = self.pool.get('stock.location')
+        location_from = move.location_id
+        location_to = quants[0].location_id
+        company_from = location_obj._location_owner(cr, uid, location_from, context=context)
+        company_to = location_obj._location_owner(cr, uid, location_to, context=context)
         context.update({'stock_move_id': move})
-        if context.get('default_inv_adjust'):
-            acc_output = move.product_id.categ_id.\
-                property_stock_account_output_categ.id
-            credit_account_id = acc_output
+        if company_to and (move.location_id.usage not in ('internal', 'transit') and move.location_dest_id.usage == 'internal' or company_from != company_to):
+            if context.get('default_inv_adjust'):
+                acc_output = move.product_id.categ_id.\
+                    property_stock_account_output_categ.id
+                credit_account_id = acc_output
         res = super(StockQuant, self)._create_account_move_line(
                 cr, uid, quants, move, credit_account_id, debit_account_id,
                 journal_id, context)

--- a/pabi_account_move_adjustment/views/stock_view.xml
+++ b/pabi_account_move_adjustment/views/stock_view.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
     <data>
+
+      <record id="stock.action_inventory_form" model="ir.actions.act_window">
+          <field name="context">{'default_inv_adjust': True}</field>
+      </record>
+
         <record id="view_inventory_form" model="ir.ui.view">
             <field name="name">stock.inventory.form</field>
             <field name="model">stock.inventory</field>

--- a/pabi_asset_management/models/stock_account.py
+++ b/pabi_asset_management/models/stock_account.py
@@ -13,7 +13,7 @@ class StockQuant(models.Model):
             cost = move.asset_value
         # Overwrite by current currency rate
         currency_id = move.picking_id.acceptance_id.order_id.currency_id.id
-        if currency_id != move.company_id.currency_id.id:
+        if currency_id and currency_id != move.company_id.currency_id.id:
             search = self.env['res.currency.rate'].search([
                 ('currency_id', '=', currency_id),
                 ('name', '<=', fields.Date.today())


### PR DESCRIPTION
Issue: https://mobileapp.nstda.or.th/redmine/issues/4459
Deployment: restart & update this only module: pabi_account_move_adjustment
แก้ไขให้ระบบบันทึกบัญชีเข้า บัญชีค่าใช้จ่าย แทน เฉพาะกรณีถ้าเป็นการปรับปรุง inventory adjust

![Selection_012](https://user-images.githubusercontent.com/52144935/79974293-41769100-84c3-11ea-82ba-5ed806657fcc.png)
cr: Stock Output Account 