### PR TITLE
[FIX] - list index out of range from account is empty

### DIFF
--- a/pabi_account_financial_report_webkit/report/common_reports.py
+++ b/pabi_account_financial_report_webkit/report/common_reports.py
@@ -145,18 +145,24 @@ class CommonReportHeaderWebkit(common_report_header):
                     amount_unpaid = 0.0
                     percent_unpaid = 0.0
                     # Check AP AR
-                    if account[0] == 'receivable':
-                        if line['debit'] - line['credit'] > 0:
-                            percent_unpaid = percent[count]
-                            amount_unpaid = line['debit'] * percent_unpaid
-                        line.update({
-                            'amount_unpaid': amount_unpaid,
-                            'percent_unpaid': percent_unpaid,
-                        })
-                    if account[0] == 'payable':
-                        if line['credit'] - line['debit'] > 0:
-                            percent_unpaid = percent[count]
-                            amount_unpaid = line['credit'] * percent_unpaid
+                    if account:
+                        if account[0] == 'receivable':
+                            if line['debit'] - line['credit'] > 0:
+                                percent_unpaid = percent[count]
+                                amount_unpaid = line['debit'] * percent_unpaid
+                            line.update({
+                                'amount_unpaid': amount_unpaid,
+                                'percent_unpaid': percent_unpaid,
+                            })
+                        if account[0] == 'payable':
+                            if line['credit'] - line['debit'] > 0:
+                                percent_unpaid = percent[count]
+                                amount_unpaid = line['credit'] * percent_unpaid
+                            line.update({
+                                'amount_unpaid': amount_unpaid,
+                                'percent_unpaid': percent_unpaid,
+                            })
+                    else:
                         line.update({
                             'amount_unpaid': amount_unpaid,
                             'percent_unpaid': percent_unpaid,


### PR DESCRIPTION
https://mobileapp.nstda.or.th/redmine/issues/4564

deployment: Restart

Error เกิดจากระบบดึงข้อมูลผิดพลาด

รายงานที่ได้รับการแก้ไข อิงตาม https://mobileapp.nstda.or.th/redmine/issues/4301 กรณี Account ไม่ใช่ AP&AR ไม่ต้องแสดง "Amount Unpaid"

![Selection_364](https://user-images.githubusercontent.com/52144935/82184913-99fa4c00-9912-11ea-9263-0e7b89f0b1e7.png)

