### PR TITLE
#4544 - [FIX] asset_adjust when move_id is False

### DIFF
--- a/pabi_asset_management/models/asset_adjust.py
+++ b/pabi_asset_management/models/asset_adjust.py
@@ -703,7 +703,8 @@ class AccountAssetAdjust(models.Model):
                     lambda l: l.type == 'depreciate' and not l.move_check
                     ).create_move()
                 # Auto post
-                self.env['account.move'].browse(move_id).post()
+                if move_id:
+                    self.env['account.move'].browse(move_id).post()
             # Set move_check equal to amount depreciated
             new_asset.compute_depreciation_board()
             new_asset.validate()


### PR DESCRIPTION
https://mobileapp.nstda.or.th/redmine/issues/4544
deployment: restart

ระบบ Error เนื่องจากกรณีระบบไม่สามารถหาข้อมูลของ move_id ได้
จึงเพิ่มเติมเงื่อนไข ให้เช็ค move_id ก่อน