### PR TITLE
Check control_ext_charge_only and Pay Type

### DIFF
--- a/account_budget_activity/models/budget_commit.py
+++ b/account_budget_activity/models/budget_commit.py
@@ -298,4 +298,8 @@ class CommitLineCommon(object):
                 reverse=reverse, currency=rec[document_field].currency_id,
                 force_currency_rate=force_currency_rate)
             if vals:
-                self.env['account.analytic.line'].sudo().create(vals)
+                line = self.env['account.analytic.line'].sudo().create(vals)
+                fiscalyear = line.fiscalyear_id
+                if fiscalyear and not fiscalyear.control_ext_charge_only and \
+                        rec.expense_id.pay_to == 'internal':
+                    line.charge_type = 'internal'


### PR DESCRIPTION
https://mobileapp.nstda.or.th/redmine/issues/4570
deployment: restart

ให้ระบบตรวจสอบ Control External Charge Only และ Pay Type 

หากไม่ได้ติ๊ก Control External Charge Only และ Pay Type เป็น Internal Charge
![Selection_458](https://user-images.githubusercontent.com/52144935/83090188-6792e080-a0c2-11ea-8867-ced879ec170b.png)
![Selection_459](https://user-images.githubusercontent.com/52144935/83090185-65c91d00-a0c2-11ea-9cf5-814b28a268e1.png)

เมื่อทำการกด "Recreate budget commitment" 
Charge Type จะเป็น Internal
![Selection_460](https://user-images.githubusercontent.com/52144935/83090369-ce17fe80-a0c2-11ea-8f24-309539ab33f3.png)


