### PR TITLE
#4583 Fix Singleton Error

### DIFF
--- a/account_budget_activity/models/budget_commit.py
+++ b/account_budget_activity/models/budget_commit.py
@@ -298,8 +298,4 @@ class CommitLineCommon(object):
                 reverse=reverse, currency=rec[document_field].currency_id,
                 force_currency_rate=force_currency_rate)
             if vals:
-                line = self.env['account.analytic.line'].sudo().create(vals)
-                fiscalyear = line.fiscalyear_id
-                if not fiscalyear.control_ext_charge_only and \
-                        rec.expense_id.pay_to == 'internal':
-                    line.charge_type = 'inter'
+                self.env['account.analytic.line'].sudo().create(vals)

--- a/l10n_th_account/models/account_voucher.py
+++ b/l10n_th_account/models/account_voucher.py
@@ -400,8 +400,9 @@ class AccountVoucher(CommonVoucher, models.Model):
             for tax_line in vals.get('tax_line_normal'):
                 if tax_line[0] == 1 and 'amount' in tax_line[2]:  # 1 = update
                     to_update = False
-        if to_update and self.is_update:
-            self.button_reset_taxes()
+        for rec in self:
+            if to_update and rec.is_update:
+                self.button_reset_taxes()
         return res
 
     @api.model


### PR DESCRIPTION
แก้ 2  ไฟล์ 
1 commit Fix sigleton แก้ไข Error เมื่อ Export Payment

commit  "Backward to origin" จาก pr https://github.com/pabi2/pb2_addons/pull/1883 แก้ไขไฟล์ผิดที่ account_budget_activity/models/budget_commit.py จึงย้อนกลับให้เป็นเหมือนเดิม

อ้างอิง 
https://mobileapp.nstda.or.th/redmine/issues/4583