### PR TITLE
#4545 [FIX] find wa 1 only

### DIFF
--- a/pabi_purchase_billing/models/purchase_billing.py
+++ b/pabi_purchase_billing/models/purchase_billing.py
@@ -177,11 +177,12 @@ class PurchaseBilling(models.Model):
             for inv in rec.supplier_invoice_ids:
                 po = inv.source_document_id
                 if po and po.use_invoice_plan:
+                    # limit 1 for case user selected wrong installment
                     wa = WA.sudo().search([
                         ('order_id', '=', po.id),
                         ('installment', '=', inv.installment),
                         ('state', '!=', 'cancel')
-                    ])
+                    ], order='id', limit=1)
                     if not wa:
                         raise ValidationError(
                             _("Can not Find Work Acceptance Installment "


### PR DESCRIPTION
แก้ไขให้ระบบหา wa กรณีที่มี wa มากกว่า 1 ค่าระบบจะเลือกงวดที่เก่าสุดเสมอ (กรณีที่ user เลือกผิดงวด)

deployment : restart only