### PR TITLE
#4679 [ADD] sequence preprint from odoo13

### DIFF
--- a/l10n_th_account_tax_detail/models/account_tax_detail.py
+++ b/l10n_th_account_tax_detail/models/account_tax_detail.py
@@ -25,8 +25,6 @@ class InvoiceVoucherTaxDetail(object):
                 doc.update({'number_preprint': preprint_number})
             # Auto create tax detail for Sales Cycle only
             for tax in doc.tax_line:
-                if tax.tax_code_type != 'normal':
-                    continue
                 invoice_tax_id = False
                 voucher_tax_id = False
                 doc_date = False
@@ -54,6 +52,9 @@ class InvoiceVoucherTaxDetail(object):
                     invoice_tax_id, voucher_tax_id, doc_date)
                 vals['invoice_number'] = preprint_number
                 doc.update({'number_preprint': preprint_number})
+                if tax.tax_code_type != 'normal':
+                    continue
+
                 detail = TaxDetail.search(domain)
                 if detail:
                     detail.write(vals)

--- a/pabi_account/models/account_invoice.py
+++ b/pabi_account/models/account_invoice.py
@@ -67,6 +67,7 @@ class AccountInvoice(models.Model):
         string='Preprint Number',
         size=500,
         copy=False,
+        readonly=True,
     )
     display_name2 = fields.Char(
         string='Partner Name',

--- a/pabi_account/models/account_voucher.py
+++ b/pabi_account/models/account_voucher.py
@@ -78,6 +78,7 @@ class AccountVoucher(models.Model):
     number_preprint = fields.Char(
         string='Preprint Number',
         size=500,
+        readonly=True,
     )
     research_type = fields.Selection(
         [('basic', 'Basic Research'),
@@ -370,7 +371,7 @@ class AccountVoucherLine(models.Model):
             move_line = rec.voucher_id.move_ids.filtered(
                 lambda l: l.account_id == income_account)
             income = calc_principal = remain_principal = 0
-            
+
             if move_line:
                 income = move_line[0].credit - move_line[0].debit
             plan = Plan.search([('move_line_id', '=', rec.move_line_id.id)])
@@ -385,7 +386,7 @@ class AccountVoucherLine(models.Model):
                     if ins.id <= plan.id:
                         remain_principal2 -= ins.calc_principal
                         a= ''
-                
+
             desc_dict = [
                 (_('{:,.2f}'.format(income) + ' บาท').rjust(50)),
                 (_('{:,.2f}'.format(calc_principal) + ' บาท').rjust(50)),

--- a/pabi_ir_sequence_preprint/__init__.py
+++ b/pabi_ir_sequence_preprint/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/pabi_ir_sequence_preprint/__openerp__.py
+++ b/pabi_ir_sequence_preprint/__openerp__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    "name": "NSTDA :: PABI2 - Sequence Preprint",
+    "summary": "New sequence by month instead pre-print",
+    "version": "8.0.1.0.0",
+    "category": "Hidden",
+    "description": """
+        Adapt sequence from odoo v13 to v8
+    """,
+    "website": "http://ecosoft.co.th",
+    "author": "Ecosoft, Odoo SA",
+    "license": "LGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": ["base"],
+    "data": [
+        "data/account_data.xml",
+        "views/ir_sequence_preprint_views.xml",
+    ],
+}

--- a/pabi_ir_sequence_preprint/data/account_data.xml
+++ b/pabi_ir_sequence_preprint/data/account_data.xml
@@ -14,6 +14,42 @@
             <field name="convert_to_buddhist_calendar">True</field>
         </record>
 
+        # Invoice Sequence
+        <record id="seq_invoice_preprint" model="ir.sequence.preprint">
+            <field name="name">Invoice Preprint</field>
+            <field name="code">invoice.preprint</field>
+            <field name="implementation">no_gap</field>
+            <field name="padding" eval="4"/>
+            <field name="prefix">IV%(year)s/%(range_month)s-</field>
+            <field name="use_date_range">True</field>
+            <field name="use_month_range">True</field>
+            <field name="convert_to_buddhist_calendar">True</field>
+        </record>
+
+        # Credit Note Tax Sequence
+        <record id="seq_credit_note_tax_preprint" model="ir.sequence.preprint">
+            <field name="name">Credit Notes Tax Preprint</field>
+            <field name="code">cn.tax.preprint</field>
+            <field name="implementation">no_gap</field>
+            <field name="padding" eval="4"/>
+            <field name="prefix">CNT%(year)s/%(range_month)s-</field>
+            <field name="use_date_range">True</field>
+            <field name="use_month_range">True</field>
+            <field name="convert_to_buddhist_calendar">True</field>
+        </record>
+
+        # Credit Note Sequence
+        <record id="seq_credit_note_tax_preprint" model="ir.sequence.preprint">
+            <field name="name">Credit Notes Preprint</field>
+            <field name="code">cn.preprint</field>
+            <field name="implementation">no_gap</field>
+            <field name="padding" eval="4"/>
+            <field name="prefix">CN%(year)s/%(range_month)s-</field>
+            <field name="use_date_range">True</field>
+            <field name="use_month_range">True</field>
+            <field name="convert_to_buddhist_calendar">True</field>
+        </record>
+
         # Receipt Tax Sequence
         <record id="seq_receipt_tax_preprint" model="ir.sequence.preprint">
             <field name="name">Receipt Tax Preprint</field>
@@ -21,6 +57,30 @@
             <field name="implementation">no_gap</field>
             <field name="padding" eval="4"/>
             <field name="prefix">RT%(year)s/%(range_month)s-</field>
+            <field name="use_date_range">True</field>
+            <field name="use_month_range">True</field>
+            <field name="convert_to_buddhist_calendar">True</field>
+        </record>
+
+        # Receipt Tax 300 % Sequence
+        <record id="seq_receipt_tax_300_preprint" model="ir.sequence.preprint">
+            <field name="name">Receipt Tax 300 Preprint</field>
+            <field name="code">receipt.tax.300.preprint</field>
+            <field name="implementation">no_gap</field>
+            <field name="padding" eval="4"/>
+            <field name="prefix">RTT%(year)s/%(range_month)s-</field>
+            <field name="use_date_range">True</field>
+            <field name="use_month_range">True</field>
+            <field name="convert_to_buddhist_calendar">True</field>
+        </record>
+
+        # Receipt Sequence
+        <record id="seq_receipt_preprint" model="ir.sequence.preprint">
+            <field name="name">Receipt Preprint</field>
+            <field name="code">receipt.preprint</field>
+            <field name="implementation">no_gap</field>
+            <field name="padding" eval="4"/>
+            <field name="prefix">RC%(year)s/%(range_month)s-</field>
             <field name="use_date_range">True</field>
             <field name="use_month_range">True</field>
             <field name="convert_to_buddhist_calendar">True</field>

--- a/pabi_ir_sequence_preprint/data/account_data.xml
+++ b/pabi_ir_sequence_preprint/data/account_data.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="1">
+
+        # Invoice Tax Sequence
+        <record id="seq_invoice_tax_preprint" model="ir.sequence.preprint">
+            <field name="name">Invoice Tax Preprint</field>
+            <field name="code">invoice.tax.preprint</field>
+            <field name="implementation">no_gap</field>
+            <field name="padding" eval="4"/>
+            <field name="prefix">IVT%(year)s/%(range_month)s-</field>
+            <field name="use_date_range">True</field>
+            <field name="use_month_range">True</field>
+        </record>
+
+        # Receipt Tax Sequence
+        <record id="seq_receipt_tax_preprint" model="ir.sequence.preprint">
+            <field name="name">Receipt Tax Preprint</field>
+            <field name="code">receipt.tax.preprint</field>
+            <field name="implementation">no_gap</field>
+            <field name="padding" eval="4"/>
+            <field name="prefix">RT%(year)s/%(range_month)s-</field>
+            <field name="use_date_range">True</field>
+            <field name="use_month_range">True</field>
+        </record>
+    </data>
+</openerp>

--- a/pabi_ir_sequence_preprint/data/account_data.xml
+++ b/pabi_ir_sequence_preprint/data/account_data.xml
@@ -11,6 +11,7 @@
             <field name="prefix">IVT%(year)s/%(range_month)s-</field>
             <field name="use_date_range">True</field>
             <field name="use_month_range">True</field>
+            <field name="convert_to_buddhist_calendar">True</field>
         </record>
 
         # Receipt Tax Sequence
@@ -22,6 +23,7 @@
             <field name="prefix">RT%(year)s/%(range_month)s-</field>
             <field name="use_date_range">True</field>
             <field name="use_month_range">True</field>
+            <field name="convert_to_buddhist_calendar">True</field>
         </record>
     </data>
 </openerp>

--- a/pabi_ir_sequence_preprint/models/__init__.py
+++ b/pabi_ir_sequence_preprint/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import ir_sequence_preprint

--- a/pabi_ir_sequence_preprint/models/ir_sequence_preprint.py
+++ b/pabi_ir_sequence_preprint/models/ir_sequence_preprint.py
@@ -1,0 +1,497 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from datetime import datetime, timedelta
+from dateutil.relativedelta import relativedelta
+import logging
+import pytz
+
+from openerp import api, fields, models, _
+from openerp.exceptions import ValidationError
+
+_logger = logging.getLogger(__name__)
+
+
+def _create_sequence(cr, seq_name, number_increment, number_next):
+    """ Create a PostreSQL sequence. """
+    if number_increment == 0:
+        raise ValidationError(_('Step must not be zero.'))
+    sql = "CREATE SEQUENCE %s INCREMENT BY %%s START WITH %%s" % seq_name
+    cr.execute(sql, (number_increment, number_next))
+
+
+def _drop_sequences(cr, seq_names):
+    """ Drop the PostreSQL sequences if they exist. """
+    names = ','.join(seq_names)
+    # RESTRICT is the default; it prevents dropping the sequence if an
+    # object depends on it.
+    cr.execute("DROP SEQUENCE IF EXISTS %s RESTRICT " % names)
+
+
+def _alter_sequence(cr, seq_name, number_increment=None, number_next=None):
+    """ Alter a PostreSQL sequence. """
+    if number_increment == 0:
+        raise ValidationError(_("Step must not be zero."))
+    cr.execute("SELECT relname FROM pg_class WHERE relkind=%s AND relname=%s",
+               ('S', seq_name))
+    if not cr.fetchone():
+        return
+    statement = "ALTER SEQUENCE %s" % (seq_name, )
+    if number_increment is not None:
+        statement += " INCREMENT BY %d" % (number_increment, )
+    if number_next is not None:
+        statement += " RESTART WITH %d" % (number_next, )
+    cr.execute(statement)
+
+
+def _select_nextval(cr, seq_name):
+    cr.execute("SELECT nextval('%s')" % seq_name)
+    return cr.fetchone()
+
+
+def _update_nogap(self, number_increment):
+    number_next = self.number_next
+    self._cr.execute("SELECT number_next FROM %s WHERE id=%s FOR UPDATE NOWAIT"
+                     % (self._table, self.id))
+    self._cr.execute("UPDATE %s SET number_next=number_next+%s WHERE id=%s "
+                     % (self._table, number_increment, self.id))
+    self.invalidate_cache(['number_next'], [self.id])
+    return number_next
+
+
+def _predict_nextval(self, seq_id):
+    """Predict next value for PostgreSQL sequence without consuming it"""
+    # Cannot use currval() as it requires prior call to nextval()
+    query = """SELECT last_value,
+                      (SELECT increment_by
+                       FROM pg_sequences
+                       WHERE sequencename = 'ir_sequence_preprint_%(seq_id)s'),
+                      is_called
+               FROM ir_sequence_preprint_%(seq_id)s"""
+    if self.env.cr._cnx.server_version < 100000:
+        query = """
+            SELECT last_value, increment_by, is_called
+            FROM ir_sequence_preprint_%(seq_id)s
+        """
+    self.env.cr.execute(query % {'seq_id': seq_id})
+    (last_value, increment_by, is_called) = self.env.cr.fetchone()
+    if is_called:
+        return last_value + increment_by
+    # sequence has just been RESTARTed to return last_value next time
+    return last_value
+
+
+class IrSequencePreprint(models.Model):
+    """ Sequence model.
+
+    The sequence model allows to define and use so-called sequence objects.
+    Such objects are used to generate unique identifiers in a transaction-safe
+    way.
+
+    """
+    _name = 'ir.sequence.preprint'
+    _description = 'Sequence'
+    _order = 'name'
+
+    @api.multi
+    @api.depends('number_next')
+    def _get_number_next_actual(self):
+        '''Return number from ir_sequence_preprint row when no_gap implementation,
+        and number from postgres sequence when standard implementation.'''
+        for seq in self:
+            if seq.implementation != 'standard':
+                seq.number_next_actual = seq.number_next
+            else:
+                seq_id = "%03d" % seq.id
+                seq.number_next_actual = _predict_nextval(self, seq_id)
+
+    @api.multi
+    def _set_number_next_actual(self):
+        for seq in self:
+            seq.write({'number_next': seq.number_next_actual or 1})
+
+    @api.model
+    def _get_current_sequence(self, sequence_date=None):
+        '''Returns the object on which we can find the number_next to consider
+        for the sequence. It could be an ir.sequence.preprint or an
+        ir.sequence.date_range depending if use_date_range is checked or not.
+        This function will also create the ir.sequence.date_range
+        if none exists yet for today
+        '''
+        if not self.use_date_range:
+            return self
+        sequence_date = sequence_date or fields.Date.today()
+        seq_date = self.env['ir.sequence.date_range'].search([
+            ('sequence_id', '=', self.id),
+            ('date_from', '<=', sequence_date),
+            ('date_to', '>=', sequence_date)], limit=1)
+        if seq_date:
+            return seq_date[0]
+        # no date_range sequence was found, we create a new one
+        return self._create_date_range_seq(sequence_date)
+
+    name = fields.Char(required=True)
+    code = fields.Char(string='Sequence Code')
+    implementation = fields.Selection([
+        ('standard', 'Standard'), ('no_gap', 'No gap')],
+        string='Implementation', required=True, default='standard',
+        help="""
+            While assigning a sequence number to a record, the 'no gap'
+            sequence implementation ensures that each previous sequence number
+            has been assigned already. While this sequence implementation will
+            not skip any sequence number upon assignation, there can still be
+            gaps in the sequence if records are deleted.
+            The 'no gap' implementation is slower than the standard one.
+        """)
+    active = fields.Boolean(default=True)
+    prefix = fields.Char(
+        help="Prefix value of the record for the sequence", trim=False)
+    suffix = fields.Char(
+        help="Suffix value of the record for the sequence", trim=False)
+    number_next = fields.Integer(
+        string='Next Number', required=True, default=1,
+        help="Next number of this sequence")
+    number_next_actual = fields.Integer(
+        compute='_get_number_next_actual', inverse='_set_number_next_actual',
+        string='Actual Next Number',
+        help="Next number that will be used. This number can be incremented "
+        "frequently so the displayed value might already be obsolete")
+    number_increment = fields.Integer(
+        string='Step', required=True, default=1,
+        help="The next number of the sequence will be incremented "
+        "by this number")
+    padding = fields.Integer(
+        string='Sequence Size', required=True, default=0,
+        help="Odoo will automatically adds some '0' on the left of the "
+        "'Next Number' to get the required padding size.")
+    company_id = fields.Many2one(
+        'res.company', string='Company',
+        default=lambda s: s.env.user.company_id)
+    use_date_range = fields.Boolean(string='Use subsequences per date_range')
+    use_month_range = fields.Boolean(string='Use month range')
+    date_range_ids = fields.One2many(
+        'ir.sequence.date_range', 'sequence_id', string='Subsequences')
+
+    @api.onchange('use_date_range')
+    def _onchange_use_date_range(self):
+        self.use_month_range = self.use_date_range
+
+    @api.model
+    def create(self, values):
+        """
+            Create a sequence, in implementation == standard a fast
+            gaps-allowed PostgreSQL sequence is used.
+        """
+        seq = super(IrSequencePreprint, self).create(values)
+        if values.get('implementation', 'standard') == 'standard':
+            _create_sequence(self._cr, "ir_sequence_preprint_%03d"
+                             % seq.id, values.get('number_increment', 1),
+                             values.get('number_next', 1))
+        return seq
+
+    @api.multi
+    def unlink(self):
+        _drop_sequences(self._cr, [
+            "ir_sequence_preprint_%03d" % x.id for x in self])
+        return super(IrSequencePreprint, self).unlink()
+
+    @api.multi
+    def write(self, values):
+        new_implementation = values.get('implementation')
+        for seq in self:
+            # 4 cases: we test the previous impl. against the new one.
+            i = values.get('number_increment', seq.number_increment)
+            n = values.get('number_next', seq.number_next)
+            if seq.implementation == 'standard':
+                if new_implementation in ('standard', None):
+                    # Implementation has NOT changed.
+                    # Only change sequence if really requested.
+                    if values.get('number_next'):
+                        _alter_sequence(self._cr, "ir_sequence_preprint_%03d"
+                                        % seq.id, number_next=n)
+                    if seq.number_increment != i:
+                        _alter_sequence(self._cr, "ir_sequence_preprint_%03d"
+                                        % seq.id, number_increment=i)
+                        seq.date_range_ids._alter_sequence(number_increment=i)
+                else:
+                    _drop_sequences(self._cr,
+                                    ["ir_sequence_preprint_%03d" % seq.id])
+                    for sub_seq in seq.date_range_ids:
+                        _drop_sequences(
+                            self._cr, ["ir_sequence_preprint_%03d_%03d"
+                                       % (seq.id, sub_seq.id)])
+            else:
+                if new_implementation in ('no_gap', None):
+                    pass
+                else:
+                    _create_sequence(self._cr, "ir_sequence_preprint_%03d"
+                                     % seq.id, i, n)
+                    for sub_seq in seq.date_range_ids:
+                        _create_sequence(self._cr,
+                                         "ir_sequence_preprint_%03d_%03d"
+                                         % (seq.id, sub_seq.id), i, n)
+        res = super(IrSequencePreprint, self).write(values)
+        # DLE P179
+        # self.flush(values.keys())
+        return res
+
+    def _next_do(self):
+        if self.implementation == 'standard':
+            number_next = _select_nextval(self._cr, 'ir_sequence_preprint_%03d'
+                                          % self.id)
+        else:
+            number_next = _update_nogap(self, self.number_increment)
+        return self.get_next_char(number_next)
+
+    def _get_prefix_suffix(self, date=None, date_range=None):
+        def _interpolate(s, d):
+            return (s % d) if s else ''
+
+        def _interpolation_dict():
+            now = range_date = effective_date = datetime.now(
+                pytz.timezone(self._context.get('tz') or 'UTC'))
+            if date or self._context.get('ir_sequence_date'):
+                effective_date = fields.Datetime.from_string(
+                    date or self._context.get('ir_sequence_date'))
+            if date_range or self._context.get('ir_sequence_date_range'):
+                range_date = fields.Datetime.from_string(
+                    date_range or self._context.get('ir_sequence_date_range'))
+
+            sequences = {
+                'year': '%Y', 'month': '%m', 'day': '%d', 'y': '%y',
+                'doy': '%j', 'woy': '%W', 'weekday': '%w', 'h24': '%H',
+                'h12': '%I', 'min': '%M', 'sec': '%S'
+            }
+            res = {}
+            for key, format in sequences.items():
+                res[key] = effective_date.strftime(format)
+                res['range_' + key] = range_date.strftime(format)
+                res['current_' + key] = now.strftime(format)
+
+            return res
+
+        d = _interpolation_dict()
+        try:
+            interpolated_prefix = _interpolate(self.prefix, d)
+            interpolated_suffix = _interpolate(self.suffix, d)
+        except ValueError:
+            raise ValidationError(_(
+                'Invalid prefix or suffix for sequence \'%s\''
+                ) % (self.get('name')))
+        return interpolated_prefix, interpolated_suffix
+
+    def get_next_char(self, number_next):
+        interpolated_prefix, interpolated_suffix = self._get_prefix_suffix()
+        return interpolated_prefix + '%%0%sd' % self.padding % number_next +\
+            interpolated_suffix
+
+    def _create_date_range_seq(self, date):
+        # if isinstance(date, basestring):
+        year = fields.Date.from_string(date).strftime('%Y')
+        month = fields.Date.from_string(date).strftime('%m')
+        date_from = fields.Date.from_string('{}-01-01'.format(year))
+        date_to = fields.Date.from_string('{}-12-31'.format(year))
+        date_range = self.env['ir.sequence.date_range'].search([
+            ('sequence_id', '=', self.id),
+            ('date_from', '>=', date),
+            ('date_from', '<=', date_to)], order='date_from desc', limit=1)
+        if date_range:
+            date_to = fields.Date.from_string(
+                date_range.date_from) + timedelta(days=-1)
+        date_range = self.env['ir.sequence.date_range'].search([
+            ('sequence_id', '=', self.id),
+            ('date_to', '>=', date_from),
+            ('date_to', '<=', date)], order='date_to desc', limit=1)
+        if self.use_month_range:
+            # BUG: date_from should be first day of month NOT first day of year
+            date_from = fields.Date.from_string('{}-{}-01'.format(year, month))
+            date_to = date_from + relativedelta(months=1) - timedelta(days=1)
+            # if date_range:
+            #     date_from = fields.Date.from_string(
+            #         date_range.date_to) + timedelta(days=1)
+        seq_date_range = self.env['ir.sequence.date_range'].sudo().create({
+            'date_from': date_from,
+            'date_to': date_to,
+            'sequence_id': self.id,
+        })
+        return seq_date_range
+
+    def _next(self, sequence_date=None):
+        """ Returns the next number in the preferred sequence in all the ones
+            given in self."""
+        if not self.use_date_range:
+            return self._next_do()
+        # date mode
+        dt = sequence_date or self._context.get(
+            'ir_sequence_date', fields.Date.today())
+        seq_date = self.env['ir.sequence.date_range'].search([
+            ('sequence_id', '=', self.id),
+            ('date_from', '<=', dt),
+            ('date_to', '>=', dt)], limit=1)
+        if not seq_date:
+            seq_date = self._create_date_range_seq(dt)
+        return seq_date.with_context(
+            ir_sequence_date_range=seq_date.date_from)._next()
+
+    def next_by_id(self, sequence_date=None):
+        """ Draw an interpolated string using the specified sequence."""
+        self.check_access_rights('read')
+        return self._next(sequence_date=sequence_date)
+
+    @api.model
+    def next_by_code(self, sequence_code, sequence_date=None):
+        """ Draw an interpolated string using a sequence with the requested code.
+            If several sequences with the correct code are available to the
+            user (multi-company cases), the one from the user's current company
+            will be used.
+
+            :param dict context: context dictionary may contain a
+                ``force_company`` key with the ID of the company to
+                use instead of the user's current company for the
+                sequence selection. A matching sequence for that
+                specific company will get higher priority.
+        """
+        self.check_access_rights('read')
+        force_company = self._context.get('force_company')
+        if not force_company:
+            force_company = self.env.user.company_id.id
+        seq_ids = self.search([
+            ('code', '=', sequence_code),
+            ('company_id', 'in', [force_company, False])], order='company_id')
+        if not seq_ids:
+            _logger.debug(
+                "No ir.sequence.preprint has been found for code '%s'. "
+                "Please make sure a sequence is set for current company."
+                % sequence_code)
+            return False
+        seq_id = seq_ids[0]
+        return seq_id._next(sequence_date=sequence_date)
+
+    @api.model
+    def get_id(self, sequence_code_or_id, code_or_id='id'):
+        """ Draw an interpolated string using the specified sequence.
+
+        The sequence to use is specified by the ``sequence_code_or_id``
+        argument, which can be a code or an id (as controlled by the
+        ``code_or_id`` argument. This method is deprecated.
+        """
+        _logger.warning(
+            "ir_sequence_preprint.get() and ir_sequence_preprint.get_id() are "
+            "deprecated. Please use ir_sequence_preprint.next_by_code() "
+            "or ir_sequence_preprint.next_by_id().")
+        if code_or_id == 'id':
+            return self.browse(sequence_code_or_id).next_by_id()
+        else:
+            return self.next_by_code(sequence_code_or_id)
+
+    @api.model
+    def get(self, code):
+        """ Draw an interpolated string using the specified sequence.
+
+        The sequence to use is specified by its code. This method is
+        deprecated.
+        """
+        return self.get_id(code, 'code')
+
+
+class IrSequenceDateRange(models.Model):
+    _name = 'ir.sequence.date_range'
+    _description = 'Sequence Date Range'
+    _rec_name = "sequence_id"
+
+    @api.multi
+    @api.depends('sequence_id')
+    def _get_number_next_actual(self):
+        '''Return number from ir_sequence_preprint row when no_gap implementation,
+        and number from postgres sequence when standard implementation.'''
+        for seq in self:
+            if seq.sequence_id.implementation != 'standard':
+                seq.number_next_actual = seq.number_next
+            else:
+                if isinstance(seq.sequence_id.id, int):
+                    seq_id = "%03d_%03d" % (seq.sequence_id.id, seq.id)
+                    seq.number_next_actual = _predict_nextval(self, seq_id)
+
+    @api.multi
+    def _set_number_next_actual(self):
+        for seq in self:
+            seq.write({'number_next': seq.number_next_actual or 1})
+
+    @api.model
+    def default_get(self, fields):
+        result = super(IrSequenceDateRange, self).default_get(fields)
+        result['number_next_actual'] = 1
+        return result
+
+    date_from = fields.Date(string='From', required=True)
+    date_to = fields.Date(string='To', required=True)
+    sequence_id = fields.Many2one(
+        "ir.sequence.preprint", string='Main Sequence', required=True,
+        ondelete='cascade')
+    number_next = fields.Integer(
+        string='Next Number', required=True, default=1,
+        help="Next number of this sequence")
+    number_next_actual = fields.Integer(
+        compute='_get_number_next_actual', inverse='_set_number_next_actual',
+        string='Actual Next Number',
+        help="Next number that will be used. This number can be incremented "
+        "frequently so the displayed value might already be obsolete")
+
+    def _next(self):
+        if self.sequence_id.implementation == 'standard':
+            number_next = _select_nextval(
+                self._cr, 'ir_sequence_preprint_%03d_%03d'
+                % (self.sequence_id.id, self.id))
+        else:
+            number_next =\
+                _update_nogap(self, self.sequence_id.number_increment)
+        return self.sequence_id.get_next_char(number_next)
+
+    @api.multi
+    def _alter_sequence(self, number_increment=None, number_next=None):
+        for seq in self:
+            _alter_sequence(self._cr, "ir_sequence_preprint_%03d_%03d"
+                            % (seq.sequence_id.id, seq.id),
+                            number_increment=number_increment,
+                            number_next=number_next)
+
+    @api.model
+    def create(self, values):
+        """ Create a sequence, in implementation == standard a fast
+            gaps-allowed PostgreSQL sequence is used.
+        """
+        seq = super(IrSequenceDateRange, self).create(values)
+        main_seq = seq.sequence_id
+        if main_seq.implementation == 'standard':
+            _create_sequence(self._cr, "ir_sequence_preprint_%03d_%03d"
+                             % (main_seq.id, seq.id),
+                             main_seq.number_increment,
+                             values.get('number_next_actual', 1))
+        return seq
+
+    @api.multi
+    def unlink(self):
+        _drop_sequences(self._cr, [
+            "ir_sequence_preprint_%03d_%03d" % (x.sequence_id.id, x.id)
+            for x in self])
+        return super(IrSequenceDateRange, self).unlink()
+
+    @api.multi
+    def write(self, values):
+        if values.get('number_next'):
+            seq_to_alter = self.filtered(
+                lambda seq: seq.sequence_id.implementation == 'standard')
+            seq_to_alter._alter_sequence(number_next=values.get('number_next'))
+        # DLE P179: `test_in_invoice_line_onchange_sequence_number_1`
+        # _update_nogap do a select to get the next sequence number_next
+        # When changing (writing) the number next of a sequence,
+        # the number next must be flushed before doing the select.
+        # Normally in such a case, we flush just above the execute,
+        # but for the sake of performance
+        # I believe this is better to flush directly in the write:
+        #  - Changing the number next of a sequence is really really rare,
+        #  - But selecting the number next happens a lot,
+        # Therefore, if I chose to put the flush just above the select,
+        # it would check the flush most of the time for no reason.
+        res = super(IrSequenceDateRange, self).write(values)
+        # self.flush(values.keys())
+        return res

--- a/pabi_ir_sequence_preprint/views/ir_sequence_preprint_views.xml
+++ b/pabi_ir_sequence_preprint/views/ir_sequence_preprint_views.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <!-- Sequences -->
+        <record id="sequence_view" model="ir.ui.view">
+            <field name="model">ir.sequence.preprint</field>
+            <field name="arch" type="xml">
+                <form string="Sequences">
+                    <sheet>
+                        <group>
+                            <group>
+                                <field name="name"/>
+                                <field name="implementation"/>
+                            </group>
+                            <group>
+                                <field name="code"/>
+                                <field name="active"/>
+                                <field name="company_id" groups="base.group_multi_company"/>
+                            </group>
+                        </group>
+                        <notebook>
+                            <page string="Sequence">
+                                <group>
+                                  <group>
+                                    <field name="prefix"/>
+                                    <field name="suffix"/>
+                                    <field name="use_date_range"/>
+                                    <field name="use_month_range" attrs="{'invisible': [('use_date_range', '=', False)]}"/>
+                                  </group>
+                                  <group>
+                                    <field name="padding"/>
+                                    <field name="number_increment"/>
+                                    <field name="number_next_actual" string="Next Number" attrs="{'invisible': [('use_date_range', '=', True)]}"/>
+                                  </group>
+                                </group>
+                                <field name="date_range_ids" attrs="{'invisible': [('use_date_range', '=', False)]}">
+                                    <tree string="Sequences" editable="top">
+                                        <field name="date_from"/>
+                                        <field name="date_to"/>
+                                        <field name="number_next_actual" string="Next Number"/>
+                                    </tree>
+                                </field>
+                                <group col="3" string="Legend (for prefix, suffix)">
+                                    <group>
+                                        <span colspan="2">Current Year with Century: %%(year)s</span>
+                                        <span colspan="2">Current Year without Century: %%(y)s</span>
+                                        <span colspan="2">Month: %%(month)s</span>
+                                        <span colspan="2">Day: %%(day)s</span>
+                                    </group>
+                                    <group>
+                                        <span colspan="2">Day of the Year: %%(doy)s</span>
+                                        <span colspan="2">Week of the Year: %%(woy)s</span>
+                                        <span colspan="2">Day of the Week (0:Monday): %%(weekday)s</span>
+                                    </group>
+                                    <group>
+                                        <span colspan="2">Hour 00->24: %%(h24)s</span>
+                                        <span colspan="2">Hour 00->12: %%(h12)s</span>
+                                        <span colspan="2">Minute: %%(min)s</span>
+                                        <span colspan="2">Second: %%(sec)s</span>
+                                    </group>
+                                </group>
+                                <group attrs="{'invisible': [('use_date_range', '=', False)]}">
+                                    <div>
+                                        When subsequences per date range are used, you can prefix variables with 'range_'
+                                        to use the beginning of the range instead of the current date, e.g. %%(range_year)s instead of %%(year)s.
+                                    </div>
+                                </group>
+                            </page>
+                        </notebook>
+                   </sheet>
+                </form>
+            </field>
+        </record>
+
+        <record id="sequence_view_tree" model="ir.ui.view">
+            <field name="model">ir.sequence.preprint</field>
+            <field name="arch" type="xml">
+                <tree string="Sequences">
+                    <field name="code"/>
+                    <field name="name"/>
+                    <field name="prefix"/>
+                    <field name="padding"/>
+                    <field name="company_id" groups="base.group_multi_company"/>
+                    <field name="number_next_actual" string="Next Number"/>
+                    <field name="number_increment"/>
+                    <field name="implementation"/>
+                </tree>
+            </field>
+        </record>
+
+        <record id="view_sequence_search" model="ir.ui.view">
+            <field name="model">ir.sequence.preprint</field>
+            <field name="arch" type="xml">
+                <search string="Sequences">
+                    <field name="name" string="Sequence"/>
+                    <field name="code"/>
+                    <field name="company_id" groups="base.group_multi_company"/>
+                    <separator/>
+                    <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
+                </search>
+            </field>
+        </record>
+
+        <record id="ir_sequence_preprint_form" model="ir.actions.act_window">
+            <field name="name">Sequences Preprint</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">ir.sequence.preprint</field>
+            <field name="view_id" ref="sequence_view_tree"/>
+            <field name="context">{'active_test': False}</field>
+        </record>
+
+        <menuitem action="ir_sequence_preprint_form" id="menu_ir_sequence_preprint_form" parent="base.next_id_5"/>
+    </data>
+</openerp>

--- a/pabi_ir_sequence_preprint/views/ir_sequence_preprint_views.xml
+++ b/pabi_ir_sequence_preprint/views/ir_sequence_preprint_views.xml
@@ -21,17 +21,18 @@
                         <notebook>
                             <page string="Sequence">
                                 <group>
-                                  <group>
-                                    <field name="prefix"/>
-                                    <field name="suffix"/>
-                                    <field name="use_date_range"/>
-                                    <field name="use_month_range" attrs="{'invisible': [('use_date_range', '=', False)]}"/>
-                                  </group>
-                                  <group>
-                                    <field name="padding"/>
-                                    <field name="number_increment"/>
-                                    <field name="number_next_actual" string="Next Number" attrs="{'invisible': [('use_date_range', '=', True)]}"/>
-                                  </group>
+                                    <group>
+                                        <field name="prefix"/>
+                                        <field name="suffix"/>
+                                        <field name="use_date_range"/>
+                                        <field name="use_month_range" attrs="{'invisible': [('use_date_range', '=', False)]}"/>
+                                    </group>
+                                    <group>
+                                        <field name="padding"/>
+                                        <field name="number_increment"/>
+                                        <field name="number_next_actual" string="Next Number" attrs="{'invisible': [('use_date_range', '=', True)]}"/>
+                                        <field name="convert_to_buddhist_calendar"/>
+                                    </group>
                                 </group>
                                 <field name="date_range_ids" attrs="{'invisible': [('use_date_range', '=', False)]}">
                                     <tree string="Sequences" editable="top">


### PR DESCRIPTION
เพิ่ม sequence ใหม่แทนการใช้ preprint
- Preprint Field ที่หน้า invoice และ payment เปลี่ยนเป็น  readonly
- ระบบจะ generate new sequence preprint ตอนสร้าง tax
- Sequence preprint สามารถเลือกให้แสดง พ.ศ. ได้
- Sequence จะรันเลขใหม่เมื่อขึ้นเดือนใหม่
- invoice จะ gen เลขที่ IVT2563/07-0001
- Receipt จะ gen เลขที่ RT2563/07-0001

deployment : restart and update module
- pabi_ir_sequence_preprint -> module ใหม่ ต้องกด Update Modules List ก่อนถึงจะเห็นนะครับ
- pabi_account