### PR TITLE
#4692_Invisible_Cheque_No

### DIFF
--- a/l10n_th_fields/views/voucher_payment_receipt_view.xml
+++ b/l10n_th_fields/views/voucher_payment_receipt_view.xml
@@ -10,7 +10,7 @@
             <field name="inherit_id" ref="account_voucher.view_vendor_receipt_form"/>
             <field name="arch" type="xml">
                 <field name="journal_id" position="after">
-                    <field name="number_cheque"/>
+ 					<field name="number_cheque" attrs="{'invisible': [('receipt_type', '!=', 'cheque')]}"/>
                     <field name="date_cheque" attrs="{'invisible': [('number_cheque','=',False)]}"/>
                     <field name="bank_cheque" attrs="{'invisible': [('number_cheque','=',False)]}"/>
                     <field name="bank_branch" attrs="{'invisible': [('number_cheque','=',False)]}"/>


### PR DESCRIPTION
FI : แก้ไขการแสดงผล เมื่อเลือก Receipt Type ที่ไม่ใช่ cheque
ให้ซ่อนฟิลด์ Cheque No.
Module : l10n_th_fields
Issues : https://mobileapp.nstda.or.th/redmine/issues/4692