### PR TITLE
[FIX] channel job to root

### DIFF
--- a/pabi_asset_management/models/asset_transfer.py
+++ b/pabi_asset_management/models/asset_transfer.py
@@ -11,7 +11,7 @@ import logging
 _logger = logging.getLogger(__name__)
 
 
-@job
+@job(default_channel='root')
 def action_done_async_process(session, model_name, res_id):
     try:
         res = session.pool[model_name].action_done_backgruond(


### PR DESCRIPTION
เพิ่ม default job asset_transfer ที่ root

deployment : restart and update module 'pabi_asset_management'