### PR TITLE
#4905 [FIX] po line fy

### DIFF
--- a/account_budget_activity/__openerp__.py
+++ b/account_budget_activity/__openerp__.py
@@ -35,6 +35,7 @@ Note: This module provide only framework. There will be no budget check here.
         'wizard/budget_release_wizard_view.xml',
         'wizard/change_release_amount_view.xml',
         'wizard/budget_technical_close.xml',
+        'wizard/edit_po_line_fy.xml',
         'views/purchase_view.xml',
         'views/purchase_requisition_view.xml',
         'views/purchase_request_view.xml',

--- a/account_budget_activity/views/purchase_view.xml
+++ b/account_budget_activity/views/purchase_view.xml
@@ -37,6 +37,7 @@
                             <tree default_order='id'>
                                 <field name="id"/>
                                 <field name="fiscalyear_id"/>
+                                <button name="%(action_edit_purchase_order_line_fy)d" string="Edit" type="action" icon="gtk-justify-fill" groups="account_budget_activity.group_budget_trans_manager"/>
                                 <field name="monitor_fy_id" string="Budget Fiscal Year"/>
                                 <field name="purchase_line_id"/>
                                 <field name="create_date"/>

--- a/account_budget_activity/wizard/__init__.py
+++ b/account_budget_activity/wizard/__init__.py
@@ -3,3 +3,4 @@ from . import purchase_request_line_make_purchase_requisition
 from . import budget_release_wizard
 from . import change_release_amount
 from . import budget_technical_close
+from . import edit_po_line_fy

--- a/account_budget_activity/wizard/edit_po_line_fy.py
+++ b/account_budget_activity/wizard/edit_po_line_fy.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from openerp import api, models, fields
+
+
+class EditPurchaseLineFY(models.TransientModel):
+    _name = 'edit.purchase.order.line.fy'
+
+    fiscalyear_id = fields.Many2one(
+        comodel_name='account.fiscalyear',
+        string='Fiscal Year',
+        required=True,
+    )
+
+    @api.model
+    def default_get(self, fields):
+        res = super(EditPurchaseLineFY, self).default_get(fields)
+        active_model = self._context.get('active_model')
+        active_id = self._context.get('active_id')
+        line = self.env[active_model].browse(active_id)
+        res['fiscalyear_id'] = line.fiscalyear_id.id
+        return res
+
+    @api.multi
+    def save(self):
+        self.ensure_one()
+        active_model = self._context.get('active_model')
+        active_id = self._context.get('active_id')
+        line = self.env[active_model].browse(active_id)
+        line.write({'fiscalyear_id': self.fiscalyear_id.id})
+        return True

--- a/account_budget_activity/wizard/edit_po_line_fy.xml
+++ b/account_budget_activity/wizard/edit_po_line_fy.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  	<data>
+		<record id="view_edit_purchase_order_line_fy" model="ir.ui.view">
+  			<field name="name">view.edit.purchase.order.line.fy</field>
+  			<field name="model">edit.purchase.order.line.fy</field>
+  			<field name="arch" type="xml">
+				<form string="Edit Invoice Date">
+                    <group>
+          			        <field name="fiscalyear_id"/>
+                    </group>
+  					<footer>
+                        <button name="save" type="object" string="Save" class="oe_highlight"/>
+                        or
+                        <button special="cancel" class="oe_link" string="Cancel"/>
+  					</footer>
+				</form>
+  			</field>
+		</record>
+
+		<record id="action_edit_purchase_order_line_fy" model="ir.actions.act_window">
+  			<field name="name">Edit Purchase Order Line FY</field>
+  			<field name="res_model">edit.purchase.order.line.fy</field>
+  			<field name="view_type">form</field>
+  			<field name="view_mode">form</field>
+  			<field name="context">{}</field>
+  			<field name="target">new</field>
+		</record>
+
+  	</data>
+</openerp>

--- a/pabi_purchase_billing/views/purchase_billing_view.xml
+++ b/pabi_purchase_billing/views/purchase_billing_view.xml
@@ -83,7 +83,7 @@
                     <notebook>
                         <page string="Supplier Invoices" >
                             <field name="supplier_invoice_ids"
-                                domain="[('is_prepaid', '=', False), ('state', '=', 'draft'), ('partner_id', '=', partner_id), ('currency_id', '=', currency_id), ('type', 'in', ('in_invoice', 'in_refund'))]" >
+                                domain="[('is_prepaid', '=', False), ('state', '=', 'draft'), ('partner_id', '=', partner_id), ('currency_id', '=', currency_id), ('type', 'in', ('in_invoice', 'in_refund')), ('purchase_billing_id', '=', False)]" >
                                 <tree>
                                     <field name="purchase_ids"/>
                                     <field name="supplier_invoice_number"/>

--- a/pabi_purchase_work_acceptance/models/account_invoice.py
+++ b/pabi_purchase_work_acceptance/models/account_invoice.py
@@ -16,6 +16,22 @@ class AccountInvoice(models.Model):
         help="List Purchase Work Acceptance with total_fine > 0.0 "
         "and not already invoiced",
     )
+    wa_id = fields.Many2one(
+        comodel_name='purchase.work.acceptance',
+        string='Work Acceptance',
+        readonly=True,
+        help="Related WA and Invoice",
+    )
+    wa_origin_id = fields.Many2one(
+        comodel_name='purchase.work.acceptance',
+        readonly=True,
+        help="WA First time, Use case cancel WA and set to draft",
+    )
+
+    @api.multi
+    def _compute_wa_id_from_origin(self):
+        for rec in self:
+            rec.wa_id = rec.wa_origin_id
 
     @api.model
     def _get_account_id_from_product(self, product, fpos):
@@ -40,7 +56,7 @@ class AccountInvoice(models.Model):
             acceptance = self.late_delivery_work_acceptance_id
             self.taxbranch_id = acceptance.order_id.taxbranch_id
             penalty_line = self.env['account.invoice.line'].new()
-            #amount_penalty = acceptance.total_fine_cal
+            # amount_penalty = acceptance.total_fine_cal
             amount_penalty = acceptance.total_fine
             if acceptance.is_manual_fine:
                 amount_penalty = acceptance.manual_fine

--- a/pabi_purchase_work_acceptance/models/purchase_work_acceptance.py
+++ b/pabi_purchase_work_acceptance/models/purchase_work_acceptance.py
@@ -114,7 +114,7 @@ class PurchaseWorkAcceptance(models.Model):
     )
     date_action = fields.Date(
         string='Action Date',
-        related = 'order_id.contract_id.action_date'
+        related='order_id.contract_id.action_date'
     )
     partner_id = fields.Many2one(
         'res.partner',
@@ -581,12 +581,15 @@ class PurchaseWorkAcceptance(models.Model):
 
     @api.multi
     def write(self, vals):
-        if vals.get('total_fine', False) and not vals.get('total_fine_cal', False):
+        if vals.get('total_fine', False) and \
+                not vals.get('total_fine_cal', False):
             vals['total_fine_cal'] = vals['total_fine']
 
         res = super(PurchaseWorkAcceptance, self).write(vals)
 
-        if vals.get('date_receive', False) or vals.get('date_contract_end', False) or vals.get('acceptance_line_ids', False):
+        if vals.get('date_receive', False) or \
+                vals.get('date_contract_end', False) or \
+                vals.get('acceptance_line_ids', False):
             self.total_fine = self.total_fine_cal
         # Redmine #2346
         self.change_invoice_detail()  # We did comment it, but set it back.
@@ -638,8 +641,8 @@ class PurchaseWorkAcceptance(models.Model):
                 )
                 amount_tax += sum([tax['amount'] for tax in taxes['taxes']])
                 amount_untaxed += taxes['total']
-            rec.amount_untaxed = round(amount_untaxed,2)
-            rec.amount_tax = round(amount_tax,2)
+            rec.amount_untaxed = round(amount_untaxed, 2)
+            rec.amount_tax = round(amount_tax, 2)
             rec.amount_total = rec.amount_untaxed + rec.amount_tax
         return True
 
@@ -707,11 +710,21 @@ class PurchaseWorkAcceptance(models.Model):
     def action_set_draft(self):
         self.ensure_one()
         self.state = 'draft'
+        invoice_id = self.env['account.invoice'].search([
+            ('wa_origin_id', '=', self.name)])
+        if invoice_id and not invoice_id.wa_id:
+            invoice_id._compute_wa_id_from_origin()
+        return True
 
     @api.multi
     def action_cancel(self):
         self.ensure_one()
+        invoice_id = self.env['account.invoice'].search([
+            ('wa_id', '=', self.name)])
+        if invoice_id:
+            invoice_id.wa_id = False
         self.state = 'cancel'
+        return True
 
     @api.model
     def open_order_line(self, ids):

--- a/pabi_purchase_work_acceptance/views/account_invoice_view.xml
+++ b/pabi_purchase_work_acceptance/views/account_invoice_view.xml
@@ -20,6 +20,7 @@
 	        <field name="arch" type="xml">
 	            <xpath expr="//field[@name='fiscal_position']" position="after">
 	                <field name="late_delivery_work_acceptance_id" />
+                    <field name="wa_id" />
 	            </xpath>
 	        </field>
 	    </record>

--- a/pabi_purchase_work_acceptance/wizard/create_purchase_work_acceptance.py
+++ b/pabi_purchase_work_acceptance/wizard/create_purchase_work_acceptance.py
@@ -75,33 +75,62 @@ class CreatePurchaseWorkAcceptance(models.TransientModel):
         self.ensure_one()
         Plan = self.env['purchase.invoice.plan']
         items = []
-        plans = Plan.search(
+        plan = Plan.search(
+            [
+                ('order_id', '=', self._context['active_id']),
+                ('ref_invoice_id.state', '=', 'draft'),
+            ],
+            order='installment', limit=1
+        )
+        select_plan = Plan.search(
             [
                 ('order_id', '=', self._context['active_id']),
                 ('ref_invoice_id.state', '=', 'draft'),
                 ('installment', '=', plan_installment),
             ],
         )
-        for plan in plans:
-            if len(plan.ref_invoice_id) == 0:
-                raise ValidationError(_("You have to create invoices first."))
-            for inv_line in plan.ref_invoice_id.invoice_line:
-                if not inv_line.product_id.id:
-                    continue
-                taxes = [(4, tax.id) for tax in inv_line.invoice_line_tax_id]
-                vals = {
-                    'line_id': inv_line.purchase_line_id.id,
-                    'product_id': inv_line.product_id.id,
-                    'name': inv_line.name or inv_line.product_id.name,
-                    'balance_qty': inv_line.purchase_line_id.product_qty,
-                    'to_receive_qty': inv_line.quantity,
-                    'product_uom': inv_line.uos_id.id,
-                    'inv_line_id': inv_line.id,
-                    'tax_ids': taxes,
-                    'price_unit': inv_line.price_unit,
-                }
-                items.append([0, 0, vals])
-            break
+        if plan.id != select_plan.id:
+            name = '#%s - %s' % (plan.installment, plan.description)
+            raise ValidationError(_("You have to select %s." % name))
+        if len(select_plan.ref_invoice_id) == 0:
+            raise ValidationError(_("You have to create invoices first."))
+        for inv_line in select_plan.ref_invoice_id.invoice_line:
+            if not inv_line.product_id.id:
+                continue
+            taxes = [(4, tax.id) for tax in inv_line.invoice_line_tax_id]
+            vals = {
+                'line_id': inv_line.purchase_line_id.id,
+                'product_id': inv_line.product_id.id,
+                'name': inv_line.name or inv_line.product_id.name,
+                'balance_qty': inv_line.purchase_line_id.product_qty,
+                'to_receive_qty': inv_line.quantity,
+                'product_uom': inv_line.uos_id.id,
+                'inv_line_id': inv_line.id,
+                'tax_ids': taxes,
+                'price_unit': inv_line.price_unit,
+            }
+            items.append([0, 0, vals])
+        # for plan in select_plan:
+        #     if len(plan.ref_invoice_id) == 0:
+        #         raise ValidationError(_(
+        #               "You have to create invoices first."))
+        #     for inv_line in plan.ref_invoice_id.invoice_line:
+        #         if not inv_line.product_id.id:
+        #             continue
+        #         taxes = [(4, tax.id) for tax in inv_line.invoice_line_tax_id]
+        #         vals = {
+        #             'line_id': inv_line.purchase_line_id.id,
+        #             'product_id': inv_line.product_id.id,
+        #             'name': inv_line.name or inv_line.product_id.name,
+        #             'balance_qty': inv_line.purchase_line_id.product_qty,
+        #             'to_receive_qty': inv_line.quantity,
+        #             'product_uom': inv_line.uos_id.id,
+        #             'inv_line_id': inv_line.id,
+        #             'tax_ids': taxes,
+        #             'price_unit': inv_line.price_unit,
+        #         }
+        #         items.append([0, 0, vals])
+        #     break
         return items
 
     @api.model
@@ -202,21 +231,7 @@ class CreatePurchaseWorkAcceptance(models.TransientModel):
     @api.model
     def _prepare_acceptance(self):
         lines = []
-        # vals = {}
         PWAcceptance = self.env['purchase.work.acceptance']
-        # vals.update({
-        #     'name': self.env['ir.sequence'].get('purchase.work.acceptance'),
-        #     'date_scheduled_end': self.date_scheduled_end,
-        #     'date_contract_start': self.date_contract_start,
-        #     'date_contract_end': self.date_scheduled_end,
-        #     'date_receive': self.date_receive,
-        #     'order_id': self.order_id.id,
-        #     'supplier_invoice': '-',
-        #     'date_invoice': self.date_receive,
-        #     'total_fine': 0,
-        #     'installment': self.select_invoice_plan,
-        # })
-        # acceptance = PWAcceptance.create(vals)
         if self.is_invoice_plan:
             items = \
                 self._prepare_acceptance_plan_line(self.select_invoice_plan)

--- a/pabi_purchase_work_acceptance/wizard/po_line_invoice.py
+++ b/pabi_purchase_work_acceptance/wizard/po_line_invoice.py
@@ -60,8 +60,11 @@ class PurchaseLineInvoice(models.TransientModel):
                 invoice_ids and invoice_ids[0] or False
             if invoice_ids and acceptance.supplier_invoice:
                 invoices = self.env['account.invoice'].browse(invoice_ids)
-                invoices.write({'supplier_invoice_number':
-                                acceptance.supplier_invoice})
+                invoices.write({
+                    'supplier_invoice_number': acceptance.supplier_invoice,
+                    'wa_id': acceptance.id,
+                    'wa_origin_id': acceptance.id
+                })
                 invoices.button_reset_taxes()
         return res
 


### PR DESCRIPTION
เพิ่มปุ่ม edit fiscalyear ที่ Tab Budget ใน Purchase Order
กรณีที่มีการทำ invoice plan และตั้งหนี้ผิดปี
โดยกลุ่มที่จะมีสิทธิ์เห็นปุ่ม edit นี้คือ group_budget_trans_manager (Transition Manager)

วิธีการใช้งานคือ เมื่อเกิดทำตั้งหนี้ผิดปี
1. แก้ไข fiscalyear ใน budgeting line ที่ทำผิดปี ให้เป็นปีที่ต้องการให้ระบบ commit budget ใหม่

deployment : restart and update module
- pabi_purchase_work_acceptance
- pabi_purchase_billing
- account_budget_activity 
============depend==============
- pabi_budget_monitor
- pabi_budget_plan_monitor
- pabi_etl