### PR TITLE
[FIX] budget breakdown internal

### DIFF
--- a/pabi_budget_plan/models/account_budget.py
+++ b/pabi_budget_plan/models/account_budget.py
@@ -220,10 +220,11 @@ class AccountBudgetLine(models.Model):
     def _filter_line_to_release(self):
         """ HOOK for use with charge_type = internal/external """
         budget_lines = super(AccountBudgetLine, self)._filter_line_to_release()
-        lines = budget_lines.filtered(lambda l: l.charge_type == 'external')
-        if not lines:
-            budget = budget_lines and budget_lines[0].budget_id or False
-            raise ValidationError(
-                _('No external expense lines for release amount, %s') %
-                budget and budget.name or 'n/a')
-        return lines
+        # lines = budget_lines.filtered(lambda l: l.charge_type == 'external')
+        # if not lines:
+        #     budget = budget_lines and budget_lines[0].budget_id or False
+        #     raise ValidationError(
+        #         _('No external expense lines for release amount %s') %
+        #         (budget and budget.name or 'n/a'))
+        # return lines
+        return budget_lines


### PR DESCRIPTION
- แก้ไขให้ระบบสามารถสร้าง budget control ได้
แม้ว่า budget plan จะเป็น internal
- แก้ไขให้ระบบแสดง validate error ให้ถูกต้อง
ปกติ error นี้จะต้องขึ้นเป็น

deployment : restart only